### PR TITLE
GSC Insights spec + dashboard mockup

### DIFF
--- a/SPECIFICATIONS/gsc-insights-and-alerts.md
+++ b/SPECIFICATIONS/gsc-insights-and-alerts.md
@@ -1,0 +1,330 @@
+# GSC Insights & Alerts (Layer 1)
+
+**Status:** 📝 Draft — pending review
+**Created:** 2026-04-18
+**Depends on:** `/sitemap.xml` route (PR #27, merged 2026-04-18)
+
+## Overview
+
+Add daily Google Search Console (GSC) monitoring to hultberg.org, with status surfaced on the `/admin/dashboard`, email alerts for severe issues, and lightweight pre-publish lint warnings in the update editor. Email delivery uses **Cloudflare Email Sending** (currently in beta) with **Resend as a documented fallback**, giving us a real-world test of the new CF service without putting auth emails at risk.
+
+This is **Layer 1** of a two-layer plan agreed during discovery on 2026-04-18:
+
+- **Layer 1 (this spec):** read-only monitoring + alerts + pre-publish lint. Always on, zero risk.
+- **Layer 2 (deferred, placeholder section below):** bounded auto-fix for a narrow allowlist of operations. Will be specced separately once Layer 1 has produced enough real data to know which fixers are actually worth building.
+
+## Motivation
+
+Google Search Console flagged hultberg.org for not having a sitemap (now fixed). Beyond that one-off, regular GSC issues will keep cropping up (sitemap entries that 404 after a slug change, indexing decisions, performance dips), and Magnus doesn't want to manually visit Search Console to find out. A small monitoring layer surfaces what matters and quietly ignores noise.
+
+The Cloudflare Email Sending service just opened up to Magnus's account (private beta, announced Nov 2025). This feature is the right low-stakes use case to try it on: if an alert is delayed or lost, no harm done. Magic-link auth emails stay on Resend.
+
+## Non-goals
+
+Explicitly **out of scope** for Layer 1:
+
+- Layer 2 autonomous fixers — deferred until we have real data
+- Migrating magic-link auth emails off Resend
+- Bulk URL Inspection across all pages (rate-limited to ~2,000/day per property; we'll spot-check, not sweep)
+- Indexing API (officially JobPosting/BroadcastEvent only — won't help us reindex updates anyway)
+- Real-time monitoring (daily cron is plenty for a personal site)
+- Historical performance dashboards beyond a 28-day rolling window
+
+## Architecture
+
+### High-level flow
+
+```
+Cron (daily 08:00 UTC)
+   ↓
+scheduled() handler
+   ↓
+GSC API client
+   ├─ sitemaps.get  (sitemap status, errors)
+   ├─ searchanalytics.query  (clicks, impressions, top queries)
+   └─ urlInspection.index.inspect  (spot-check homepage + newest 3 updates)
+   ↓
+Compare against previous snapshot in KV
+   ↓
+   ├─ Persist new snapshot to GSC_KV
+   ├─ Render dashboard payload
+   └─ Detect severe events → notifier
+                                ↓
+                        env.SEND_EMAIL.send(...)
+                                ↓ (on failure)
+                        Resend fallback
+```
+
+### Authentication to GSC
+
+**Choice:** Google service account, added as a user on the Search Console property.
+
+- No human OAuth flow, no refresh-token plumbing.
+- Service account JSON stored as a wrangler secret (`GSC_SERVICE_ACCOUNT_JSON`) — single-line stringified JSON.
+- Worker signs a JWT with RS256 using Web Crypto (`SubtleCrypto.sign`), exchanges it for an OAuth access token at `https://oauth2.googleapis.com/token`, caches the token in memory for its 1h lifetime.
+- **Setup ceremony** (one-time, documented in `REFERENCE/environment-setup.md`):
+  1. Create service account in a Google Cloud project, generate JSON key.
+  2. Enable the Search Console API on the project.
+  3. Add the service account email as a user (with Owner or Full permissions) on the `https://hultberg.org/` property in Search Console.
+  4. `wrangler secret put GSC_SERVICE_ACCOUNT_JSON` (paste the JSON).
+
+### Storage
+
+New KV namespace: **`GSC_KV`**.
+
+| Key pattern | Contents | TTL |
+|---|---|---|
+| `status:latest` | Most recent full snapshot (sitemap status, indexed count, top queries, alert flags) | none |
+| `status:history:{YYYYMMDD}` | Daily snapshot for trend lines | 35 days |
+| `alert:dedup:{type}:{key}` | Prevents repeated alerts for the same issue within 24h | 24h |
+| `lint:rules` | Cached lint rule config (future-proofing; static for v1) | none |
+
+### Scheduling
+
+Cloudflare Workers Cron Triggers — native, free, no external scheduler.
+
+- Schedule: `0 8 * * *` (08:00 UTC daily)
+- Trigger registered in `wrangler.toml`
+- New `scheduled(event, env, ctx)` export added alongside existing `fetch` handler in `src/index.ts`
+
+### Email delivery
+
+A new `src/notifier.ts` module abstracts email sending behind a single `sendAlert(env, alert)` function:
+
+1. If `env.SEND_EMAIL` binding is available, call `env.SEND_EMAIL.send(...)`.
+2. On thrown error or non-success response, fall back to Resend via the existing `src/email.ts` pattern (extracted into a reusable `sendViaResend(env, ...)` helper).
+3. Log which path was used (`provider:cf` / `provider:resend-fallback`) so we can monitor CF Email Sending reliability over time.
+
+The magic-link auth email in `src/email.ts` is **not migrated** — it continues to call Resend directly. Documented decision (see ADR below).
+
+## Surface areas
+
+### 1. Admin dashboard widget
+
+A new card on `/admin/dashboard` showing:
+
+- **Sitemap status:** last submitted, last downloaded, errors/warnings count, indexed-vs-submitted ratio
+- **Indexing health:** current indexed count + 7/28-day delta
+- **Top queries (last 28 days):** top 5 by clicks, with impressions and CTR
+- **Recent alerts:** last 3 alerts (severity, message, timestamp), dismissable
+- **Data freshness:** "Last refreshed: X hours ago" — turns red if >36h
+- **Manual refresh button:** triggers the same code path as the cron, useful during development and when Magnus is curious
+
+Implementation:
+- Server-side: `GET /admin/api/gsc-status` returns `status:latest` from KV (auth-gated like other admin APIs)
+- Server-side: `POST /admin/api/refresh-gsc` re-runs the GSC poll on demand
+- Client-side: `public/admin/gsc-widget.js` fetches and renders into a container in `adminDashboard.ts`
+
+### 2. Email alerts
+
+Sent only for **severe** events (high signal, low frequency):
+
+| Event | Trigger | Severity |
+|---|---|---|
+| Indexed-page count drop ≥20% | Two consecutive daily observations both show the drop (avoids data-lag false positives) | 🟠 High |
+| Sitemap fetch failure | Two consecutive cron runs see a sitemap error | 🟠 High |
+| New crawl error category appears | First time we see a previously-absent error type | 🟡 Medium |
+| Sudden impressions drop ≥50% (28d rolling) | Indirect proxy for manual actions / penalties — Google may have suppressed the site | 🟡 Medium |
+
+> **Note on manual actions and security issues:** The GSC v1 API does **not** expose `manualActions` or `securityIssues` resources. When these occur, Google emails the verified property owner directly. The dashboard surfaces a "Last manual-actions check in GSC UI: X days ago" reminder rather than trying to duplicate Google's notification. The "sudden impressions drop" alert above is a weak indirect proxy.
+
+Deduplication: `alert:dedup:{type}:{key}` prevents spamming. Same alert will not re-send within 24h.
+
+### 3. Pre-publish lint (in update editor)
+
+Before publishing an update (`status: draft → published`), display non-blocking warnings if:
+
+- No meta description (we'll auto-fill from `excerpt` if present, otherwise warn)
+- Title duplicates an existing published update's title (case-insensitive)
+- Content shorter than 300 characters (likely too thin for indexing)
+- No images and excerpt is empty (poor social/preview rendering)
+
+Warnings appear in the editor; they do not block publish. Magnus can publish through them deliberately.
+
+## Files
+
+### New files
+
+```
+src/
+  ├── gsc.ts                    GSC API client (auth + endpoints)
+  ├── jwt.ts                    RS256 JWT signing via Web Crypto
+  ├── scheduled.ts              Cron handler — orchestrates daily poll
+  ├── notifier.ts               Email abstraction (CF + Resend fallback)
+  ├── lint.ts                   Pre-publish lint rules (pure functions)
+  └── routes/
+      ├── gscStatus.ts          GET /admin/api/gsc-status
+      └── refreshGsc.ts         POST /admin/api/refresh-gsc
+
+public/
+  └── admin/
+      └── gsc-widget.js         Client-side rendering of dashboard widget
+
+tests/
+  ├── unit/
+  │   ├── jwt.test.ts
+  │   ├── lint.test.ts
+  │   └── notifier.test.ts
+  └── integration/
+      ├── scheduled.test.ts
+      ├── gscStatus.test.ts
+      └── refreshGsc.test.ts
+```
+
+### Modified files
+
+```
+src/index.ts                  Add `scheduled` export, register new admin routes
+src/types.ts                  Add SEND_EMAIL binding to Env, new GSC* interfaces
+src/email.ts                  Extract sendViaResend helper for reuse from notifier
+src/routes/adminDashboard.ts  Add widget container + script include
+src/routes/saveUpdate.ts      Surface lint warnings in response (non-blocking)
+src/routes/adminEditor.ts     Render lint warnings in editor UI on save
+wrangler.toml                 Add GSC_KV namespace, SEND_EMAIL binding, cron trigger
+.dev.vars.example             Document GSC_SERVICE_ACCOUNT_JSON
+```
+
+## Data structures
+
+```typescript
+// In src/types.ts
+
+export interface GSCSnapshot {
+  capturedAt: string;          // ISO 8601
+  sitemap: {
+    lastSubmitted: string | null;
+    lastDownloaded: string | null;
+    errors: number;
+    warnings: number;
+    submitted: number;
+    indexed: number;
+  };
+  indexing: {
+    indexedCount: number;
+    deltaVs7d: number;
+    deltaVs28d: number;
+  };
+  performance: {
+    period: '28d';
+    totalClicks: number;
+    totalImpressions: number;
+    avgCtr: number;
+    avgPosition: number;
+    topQueries: Array<{
+      query: string;
+      clicks: number;
+      impressions: number;
+      ctr: number;
+      position: number;
+    }>;
+  };
+  alerts: GSCAlert[];
+  emailDelivery: {
+    lastProvider: 'cf' | 'resend-fallback' | null;
+    lastSuccessAt: string | null;
+    lastErrorAt: string | null;
+  };
+}
+
+export interface GSCAlert {
+  type: 'indexed-drop' | 'sitemap-error' | 'new-crawl-error' | 'impressions-drop';
+  severity: 'high' | 'medium';
+  message: string;
+  detectedAt: string;
+  emailSent: boolean;
+}
+```
+
+## Architecture decisions to record as ADRs
+
+Per `.claude/CLAUDE.md`, decisions that shape future architecture should become ADRs in `REFERENCE/decisions/`. Proposing three:
+
+1. **ADR — Use service account auth (not OAuth) for GSC.** Rationale: cron-driven, no human in the loop. Trade-off: must keep service account JSON as a secret; rotation is a manual step.
+2. **ADR — Cloudflare Email Sending as default with Resend fallback.** Rationale: try CF native on a low-stakes feature. Trade-off: beta service, unknown pricing, but we have a fallback. Bounded scope: this decision applies only to non-auth notifications; auth emails stay on Resend until CF is GA + has a clean track record on alerts.
+3. **ADR — Defer Layer 2 auto-fix.** Rationale: most GSC "issues" aren't code-fixable; want real data before building fixers. Trade-off: Magnus has to action some issues manually.
+
+## Testing strategy
+
+Following `REFERENCE/testing-strategy.md`:
+
+**Unit:**
+- `jwt.ts` — sign known input, verify output decodes correctly with public key
+- `lint.ts` — each rule tested independently with passing and failing examples
+- `notifier.ts` — mock `env.SEND_EMAIL` and Resend; verify fallback on each failure mode (binding missing, send throws, send returns non-success)
+
+**Integration:**
+- `scheduled.test.ts` — full cron run with mocked GSC API, assert KV writes, alert generation, email path selection
+- `gscStatus.test.ts` — auth required, returns latest snapshot, handles missing snapshot
+- `refreshGsc.test.ts` — auth required, triggers the same code as scheduled
+
+**Coverage target:** 95%+ lines/functions/statements, 90%+ branches (project standard).
+
+**Manual:**
+- Trigger cron via `wrangler triggers cron` and observe email
+- Force CF Email Sending failure (e.g., bad `from` domain) and verify Resend fallback
+- Submit a draft update with no meta description, observe lint warning in editor
+- Visit `/admin/dashboard`, observe widget renders with real data
+
+## Edge cases & risks
+
+- **GSC quota exhaustion.** Daily baseline is ~5 calls (sitemaps + searchanalytics + a handful of inspections). Well under any quota. Manual refresh adds a few more — guard against rapid clicking with a simple in-memory rate limit.
+- **Service account JSON rotation.** Document the steps in `environment-setup.md`. Risk: rotation gets forgotten and tokens expire silently. Mitigation: dashboard widget shows freshness; >36h stale turns red.
+- **CF Email Sending outage / beta breakage.** Resend fallback handles it. If both fail, log + skip (next cron run will retry). Failures don't crash the cron handler.
+- **GSC data lag (1–2 days).** Mitigated by requiring 2 consecutive observations before triggering "indexed drop" or "sitemap error" alerts.
+- **KV write failure.** Tolerate; next cron run retries. Don't fail the whole run because one write blipped.
+- **Cron didn't run** (Cloudflare incident). Dashboard widget surfaces "stale" state if `status:latest` is >36h old.
+- **Service account leaked.** It only has Search Console read access for one property — blast radius is read-only GSC data, not the site. Still, rotate immediately if leaked.
+
+## PR plan
+
+Likely two PRs to keep reviews tractable:
+
+**PR 1 — Plumbing (no UI):**
+- `gsc.ts`, `jwt.ts`, `scheduled.ts`, `notifier.ts`
+- KV namespace, cron trigger, secrets in wrangler.toml
+- Tests for the above
+- ADRs in `REFERENCE/decisions/`
+- After merge: configure secrets, verify cron runs, verify email arrives
+
+**PR 2 — UI surfaces:**
+- `gscStatus.ts`, `refreshGsc.ts`, `gsc-widget.js`
+- Pre-publish lint integrated into editor
+- Tests
+- `REFERENCE/gsc-insights.md` how-it-works doc
+
+Branch naming: `feature/gsc-insights-plumbing` and `feature/gsc-insights-ui`.
+
+## Open questions
+
+1. **Email recipient.** Use existing `ADMIN_EMAIL` env var (currently `magnus.hultberg@gmail.com`)? Assumption: yes.
+2. **Manual refresh rate limit.** One per minute via in-memory map? Or skip rate limiting for v1? Assumption: skip — it's a single-admin endpoint behind auth.
+3. **Indexed-drop threshold.** Defaulting to 20% / 2 consecutive observations. Magnus to confirm.
+4. **Lint warning UI.** Toast / banner / inline next to fields? Assumption: a yellow banner above the editor's publish button.
+5. **CF Email Sending cost.** Pricing not finalized as of Apr 2026. We accept this — re-evaluate if billing surprises us.
+6. **Search Analytics property URL form.** GSC supports both URL-prefix and Domain properties. Which is configured for hultberg.org? (Will check during PR 1 setup.)
+
+## Future work — Layer 2 placeholder
+
+Once Layer 1 has produced ~3 months of real data, evaluate whether to build a bounded auto-fix layer for a narrow allowlist:
+
+- **Sitemap pruning:** exclude URLs GSC reports as 404 / redirected from the next sitemap regen.
+- **Auto-canonical:** add `<link rel="canonical">` to update pages that lack one (always self-referential — deterministic).
+- **Auto-fill meta description:** populate empty meta descriptions from `excerpt` at render time.
+
+**Explicitly NOT in scope without further discovery:**
+
+- Anything touching robots.txt, redirects, page templates, or layout
+- Anything that "improves content" (rewriting titles/excerpts/copy)
+- Anything that requires judgment about why Google chose not to index something
+- Bulk operations across many URLs without per-item review
+
+A separate spec (`gsc-auto-fix-layer-2.md`) will be drafted at that point, informed by what Layer 1 actually surfaced.
+
+## Related documentation
+
+- [Root CLAUDE.md](../CLAUDE.md) — project navigation
+- [environment-setup.md](../REFERENCE/environment-setup.md) — to be updated with `GSC_SERVICE_ACCOUNT_JSON` instructions
+- [testing-strategy.md](../REFERENCE/testing-strategy.md)
+- [Google Search Console API docs](https://developers.google.com/webmaster-tools/v1/api_reference_index)
+- [URL Inspection API docs](https://developers.google.com/webmaster-tools/v1/urlInspection.index)
+- [Cloudflare Email Sending announcement](https://blog.cloudflare.com/email-service/)

--- a/SPECIFICATIONS/mockups/gsc-dashboard.html
+++ b/SPECIFICATIONS/mockups/gsc-dashboard.html
@@ -96,6 +96,8 @@
       flex: 1;
       color: #212529;
     }
+    .widget-header h2 a { color: #0d6efd; text-decoration: none; }
+    .widget-header h2 a:hover { text-decoration: underline; }
     .widget-header .freshness {
       font-size: 0.8em;
       color: #6c757d;
@@ -270,7 +272,7 @@
     <!-- ==================== GSC INSIGHTS WIDGET ==================== -->
     <section class="widget" aria-label="Search visibility">
       <div class="widget-header">
-        <h2>Search visibility</h2>
+        <h2>Search visibility (<a href="https://search.google.com/search-console?resource_id=http%3A%2F%2Fhultberg.org%2F" target="_blank" rel="noopener">GSC</a>)</h2>
         <span class="freshness">Last refreshed 4h ago</span>
         <button class="refresh" type="button">↻ Refresh</button>
       </div>

--- a/SPECIFICATIONS/mockups/gsc-dashboard.html
+++ b/SPECIFICATIONS/mockups/gsc-dashboard.html
@@ -1,0 +1,401 @@
+<!DOCTYPE html>
+<!--
+  ABOUT: High-fidelity mockup for the GSC Insights widget on /admin/dashboard.
+  ABOUT: Standalone HTML seeded with plausible-but-fake data for hultberg.org.
+
+  This file is NOT wired into the Worker — open it directly in a browser to
+  review layout, density, and visual hierarchy.
+
+  Design notes:
+  - Widget sits ABOVE the existing Updates table so SEO status is the first
+    thing seen on visiting /admin/dashboard (the "morning check").
+  - Uses the same design tokens as src/routes/adminDashboard.ts (fonts,
+    colours, card shadows, badge palette).
+  - Four KPI tiles (Indexed / Sitemap / Clicks / Impressions) provide at-a-glance
+    health.
+  - One compact "top queries" list keeps the performance story close without
+    turning the dashboard into a mini-GSC.
+  - Alerts render inline at the top of the widget when present.
+  - A small "Manual actions & security" reminder acknowledges the GSC API gap.
+-->
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <title>Admin Dashboard (mockup) - hultberg.org</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      line-height: 1.5;
+      color: #333;
+      margin: 0;
+      background: #f8f9fa;
+    }
+    /* Mockup banner */
+    .mockup-banner {
+      background: #fff3cd;
+      color: #856404;
+      padding: 8px 16px;
+      text-align: center;
+      font-size: 0.85em;
+      border-bottom: 1px solid #ffeaa7;
+    }
+    .mockup-banner strong { font-weight: 600; }
+
+    /* Header — copied from adminDashboard.ts */
+    header {
+      background: #212529;
+      color: #fff;
+      padding: 12px 24px;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+    header .brand { font-weight: 700; font-size: 1.1em; flex: 1; color: #fff; text-decoration: none; }
+    header nav a { color: #adb5bd; text-decoration: none; margin-right: 16px; }
+    header nav a:hover { color: #fff; }
+    header .user { color: #adb5bd; font-size: 0.85em; margin-right: 12px; }
+    header form { margin: 0; }
+    header button {
+      background: transparent;
+      border: 1px solid #6c757d;
+      color: #adb5bd;
+      padding: 4px 12px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 0.85em;
+    }
+    header button:hover { border-color: #adb5bd; color: #fff; }
+    main { max-width: 960px; margin: 32px auto; padding: 0 24px; }
+    h1 { font-size: 1.4em; margin: 0 0 20px; }
+
+    a { color: #0d6efd; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    /* GSC widget */
+    .widget {
+      background: #fff;
+      border-radius: 6px;
+      box-shadow: 0 1px 3px rgba(0,0,0,.1);
+      margin-bottom: 24px;
+      overflow: hidden;
+    }
+    .widget-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 20px;
+      border-bottom: 1px solid #f1f3f5;
+    }
+    .widget-header h2 {
+      font-size: 1em;
+      font-weight: 600;
+      margin: 0;
+      flex: 1;
+      color: #212529;
+    }
+    .widget-header .freshness {
+      font-size: 0.8em;
+      color: #6c757d;
+    }
+    .widget-header .freshness.stale { color: #dc3545; font-weight: 600; }
+    .widget-header button.refresh {
+      background: transparent;
+      border: 1px solid #dee2e6;
+      color: #495057;
+      padding: 4px 10px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 0.8em;
+    }
+    .widget-header button.refresh:hover { border-color: #adb5bd; background: #f8f9fa; }
+
+    /* Alerts strip */
+    .alerts {
+      padding: 0 20px;
+    }
+    .alert {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 12px 14px;
+      border-radius: 4px;
+      margin: 12px 0;
+      font-size: 0.88em;
+    }
+    .alert .icon { font-size: 1.1em; line-height: 1; }
+    .alert .body { flex: 1; }
+    .alert .body .title { font-weight: 600; color: #212529; }
+    .alert .body .meta { color: #6c757d; font-size: 0.85em; margin-top: 2px; }
+    .alert.medium { background: #fff3cd; border-left: 3px solid #ffc107; }
+    .alert.high   { background: #f8d7da; border-left: 3px solid #dc3545; }
+    .alert button.dismiss {
+      background: transparent;
+      border: none;
+      color: #6c757d;
+      cursor: pointer;
+      font-size: 1.1em;
+      padding: 0 4px;
+    }
+    .alert button.dismiss:hover { color: #212529; }
+
+    /* KPI tiles */
+    .tiles {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 12px;
+      padding: 16px 20px;
+    }
+    .tile {
+      background: #f8f9fa;
+      border: 1px solid #f1f3f5;
+      border-radius: 6px;
+      padding: 14px;
+    }
+    .tile .label {
+      font-size: 0.75em;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #6c757d;
+      margin-bottom: 6px;
+    }
+    .tile .value {
+      font-size: 1.6em;
+      font-weight: 700;
+      color: #212529;
+      line-height: 1.1;
+    }
+    .tile .sub {
+      font-size: 0.8em;
+      color: #6c757d;
+      margin-top: 4px;
+    }
+    .tile .delta.up { color: #155724; }
+    .tile .delta.down { color: #721c24; }
+    .tile .delta.flat { color: #6c757d; }
+
+    /* Top queries */
+    .queries {
+      padding: 4px 20px 16px;
+    }
+    .queries h3 {
+      font-size: 0.8em;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #6c757d;
+      margin: 12px 0 8px;
+    }
+    .queries table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9em;
+    }
+    .queries td {
+      padding: 6px 0;
+      border-top: 1px solid #f1f3f5;
+      vertical-align: middle;
+    }
+    .queries tr:first-child td { border-top: none; }
+    .queries td.query { color: #212529; }
+    .queries td.metrics {
+      text-align: right;
+      color: #6c757d;
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }
+    .queries td.metrics .clicks { font-weight: 600; color: #212529; margin-right: 10px; }
+
+    /* Manual-actions reminder */
+    .manual-reminder {
+      padding: 12px 20px;
+      font-size: 0.82em;
+      color: #6c757d;
+      background: #fafbfc;
+      border-top: 1px solid #f1f3f5;
+      display: flex;
+      gap: 10px;
+      align-items: center;
+    }
+    .manual-reminder .icon { font-size: 1em; }
+    .manual-reminder a { color: #0d6efd; }
+
+    /* Existing dashboard styles (for context) */
+    .actions { display: flex; justify-content: flex-end; margin-bottom: 16px; }
+    .btn-primary {
+      background: #212529;
+      color: #fff;
+      padding: 8px 16px;
+      border-radius: 4px;
+      text-decoration: none;
+      font-size: 0.9em;
+    }
+    .btn-primary:hover { background: #343a40; }
+    table.updates { width: 100%; border-collapse: collapse; background: #fff; border-radius: 6px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
+    table.updates th { background: #f1f3f5; font-size: 0.8em; text-transform: uppercase; letter-spacing: .05em; color: #6c757d; padding: 10px 14px; text-align: left; }
+    table.updates td { padding: 12px 14px; border-top: 1px solid #f1f3f5; vertical-align: middle; font-size: 0.9em; }
+    table.updates tr:hover td { background: #fafafa; }
+    .badge { padding: 2px 8px; border-radius: 12px; font-size: 0.8em; font-weight: 600; }
+    .badge.published { background: #d4edda; color: #155724; }
+    .badge.draft { background: #fff3cd; color: #856404; }
+    footer { text-align: center; color: #adb5bd; font-size: 0.8em; padding: 32px 24px; }
+    footer a { color: #adb5bd; }
+
+    @media (max-width: 720px) {
+      .tiles { grid-template-columns: repeat(2, 1fr); }
+    }
+  </style>
+</head>
+<body>
+  <div class="mockup-banner">
+    <strong>Mockup</strong> — Static HTML, dummy data. See <code>SPECIFICATIONS/gsc-insights-and-alerts.md</code> for spec.
+  </div>
+
+  <header>
+    <a class="brand" href="#">hultberg.org admin</a>
+    <nav>
+      <a href="#" aria-current="page">Dashboard</a>
+      <a href="#">Now</a>
+    </nav>
+    <span class="user">magnus.hultberg@gmail.com</span>
+    <form method="POST" action="#">
+      <button type="submit">Logout</button>
+    </form>
+  </header>
+
+  <main>
+
+    <!-- ==================== GSC INSIGHTS WIDGET ==================== -->
+    <section class="widget" aria-label="Search visibility">
+      <div class="widget-header">
+        <h2>Search visibility</h2>
+        <span class="freshness">Last refreshed 4h ago</span>
+        <button class="refresh" type="button">↻ Refresh</button>
+      </div>
+
+      <!-- Alerts strip: shown only when alerts exist. Dummy: one medium alert. -->
+      <div class="alerts">
+        <div class="alert medium">
+          <span class="icon">⚠️</span>
+          <div class="body">
+            <div class="title">Sitemap reports 1 warning</div>
+            <div class="meta">Google couldn't reach <code>/updates/old-slug-that-got-renamed</code>. Seen for 2 consecutive days.</div>
+          </div>
+          <button class="dismiss" type="button" aria-label="Dismiss">×</button>
+        </div>
+      </div>
+
+      <!-- KPI tiles -->
+      <div class="tiles">
+        <div class="tile">
+          <div class="label">Indexed pages</div>
+          <div class="value">24</div>
+          <div class="sub"><span class="delta up">+2</span> vs 28d ago</div>
+        </div>
+        <div class="tile">
+          <div class="label">Sitemap</div>
+          <div class="value">24<span style="font-size:0.6em;color:#6c757d;font-weight:400;"> / 26</span></div>
+          <div class="sub">indexed / submitted</div>
+        </div>
+        <div class="tile">
+          <div class="label">Clicks (28d)</div>
+          <div class="value">312</div>
+          <div class="sub"><span class="delta up">+18%</span> vs prior 28d</div>
+        </div>
+        <div class="tile">
+          <div class="label">Impressions (28d)</div>
+          <div class="value">8,432</div>
+          <div class="sub"><span class="delta up">+12%</span> vs prior 28d</div>
+        </div>
+      </div>
+
+      <!-- Top queries -->
+      <div class="queries">
+        <h3>Top queries · last 28 days</h3>
+        <table>
+          <tbody>
+            <tr>
+              <td class="query">magnus hultberg</td>
+              <td class="metrics"><span class="clicks">145</span> 3,204 impr · 4.5% CTR · pos 2.1</td>
+            </tr>
+            <tr>
+              <td class="query">flying jacob recipe</td>
+              <td class="metrics"><span class="clicks">62</span> 1,128 impr · 5.5% CTR · pos 4.8</td>
+            </tr>
+            <tr>
+              <td class="query">char.gy product manager</td>
+              <td class="metrics"><span class="clicks">42</span> 981 impr · 4.3% CTR · pos 6.2</td>
+            </tr>
+            <tr>
+              <td class="query">now page idea</td>
+              <td class="metrics"><span class="clicks">28</span> 452 impr · 6.2% CTR · pos 3.4</td>
+            </tr>
+            <tr>
+              <td class="query">claude code template</td>
+              <td class="metrics"><span class="clicks">19</span> 614 impr · 3.1% CTR · pos 8.9</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Manual actions reminder -->
+      <div class="manual-reminder">
+        <span class="icon">ⓘ</span>
+        <div>
+          Manual actions &amp; security issues aren't in the GSC API — Google emails you directly when they occur.
+          Last checked in GSC UI: <strong>12 days ago</strong>.
+          <a href="https://search.google.com/search-console/manual-actions" target="_blank" rel="noopener">Check now ↗</a>
+        </div>
+      </div>
+    </section>
+    <!-- ==================== /GSC INSIGHTS WIDGET ==================== -->
+
+    <!-- Existing updates management (unchanged, shown for context) -->
+    <div class="actions">
+      <a class="btn-primary" href="#">+ New Update</a>
+    </div>
+
+    <table class="updates">
+      <thead>
+        <tr>
+          <th>Title</th>
+          <th>Status</th>
+          <th>Published</th>
+          <th>Last edited</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a href="#">Are you over-engineering your Claude Code projects?</a></td>
+          <td><span class="badge published">published</span></td>
+          <td>6 Apr 2026</td>
+          <td>6 Apr 2026</td>
+          <td><a href="#">Edit</a></td>
+        </tr>
+        <tr>
+          <td><a href="#">Ansible: AI-powered triage for your Readwise library</a></td>
+          <td><span class="badge published">published</span></td>
+          <td>2 Apr 2026</td>
+          <td>2 Apr 2026</td>
+          <td><a href="#">Edit</a></td>
+        </tr>
+        <tr>
+          <td><a href="#">On being honest about AI</a></td>
+          <td><span class="badge draft">draft</span></td>
+          <td>—</td>
+          <td>31 Mar 2026</td>
+          <td><a href="#">Edit</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </main>
+
+  <footer>
+    Mockup preview · not connected to live data · iterate freely
+  </footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Documentation-only PR introducing:
- **Spec:** `SPECIFICATIONS/gsc-insights-and-alerts.md` — Layer 1 plan for daily GSC monitoring, dashboard widget, severe-event email alerts, and pre-publish lint warnings. Email delivery uses Cloudflare Email Sending (beta) with Resend as documented fallback. Magic-link auth stays on Resend. Layer 2 auto-fix is explicitly deferred.
- **Mockup:** `SPECIFICATIONS/mockups/gsc-dashboard.html` — high-fidelity standalone HTML preview of the proposed widget on `/admin/dashboard`, seeded with plausible-but-fake data. Open in a browser; not wired into the Worker.

## Discovery decisions captured in spec

- Service account auth (not OAuth) for GSC API
- Cloudflare Email Sending as default with Resend fallback (only for non-auth notifications)
- Layer 2 (autonomous fixers) deferred until Layer 1 produces real data
- GSC v1 API does **not** expose `manualActions` or `securityIssues` resources — alert table corrected; dashboard surfaces a "Last manual-actions check in GSC UI" reminder instead

## Not in this PR

No Worker code, no tests, no wrangler config changes. Implementation lands in two follow-up PRs (plumbing + UI) once the GCP service account is set up.

## Next step (gating, on Magnus)

Before implementation can begin:
1. Create a service account in a Google Cloud project
2. Enable the Search Console API on the project
3. Add the service account email as a user (Owner or Full) on the `https://hultberg.org/` property in Search Console
4. Generate JSON key (we'll store it as a wrangler secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)