### PR TITLE
GSC Insights UI — dashboard widget + status/refresh endpoints + pre-publish lint (Layer 1 PR 2/2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 node_modules
 .wrangler/
 .entire/
-package-lock.json
 .DS_Store
 
 # Local development directories

--- a/REFERENCE/gsc-insights.md
+++ b/REFERENCE/gsc-insights.md
@@ -1,0 +1,169 @@
+# GSC Insights & Alerts
+
+**Feature status:** Shipped in PRs #29 (plumbing) and PR 2 (UI + lint)
+**Primary spec:** [`SPECIFICATIONS/ARCHIVE/gsc-insights-and-alerts.md`](../SPECIFICATIONS/ARCHIVE/gsc-insights-and-alerts.md)
+**Related ADRs:** [service-account auth](./decisions/2026-04-18-gsc-service-account-auth.md) · [CF Email Sending + Resend fallback](./decisions/2026-04-18-cf-email-sending-with-resend-fallback.md) · [defer Layer 2](./decisions/2026-04-18-defer-gsc-auto-fix-layer.md)
+
+## What this feature does
+
+Daily monitoring of Google Search Console for hultberg.org:
+
+- **Daily poll (cron)** — 08:00 UTC each day, the Worker signs a JWT, exchanges it for an OAuth token, fetches sitemap status + search analytics from GSC, and persists a snapshot to KV.
+- **Dashboard widget** (`/admin/dashboard`) — shows sitemap status, indexed page count, 28-day clicks/impressions with deltas, top queries, and any active alerts. Includes a manual "Refresh" button.
+- **Email alerts** for severe-only events (indexed-page drop, sitemap errors, new sitemap warnings, impressions drop). Sent via Cloudflare Email Sending (beta) with Resend fallback.
+- **Pre-publish lint** in the update editor — non-blocking warnings for missing excerpt, thin content, duplicate title, poor social-preview potential.
+
+## Architecture at a glance
+
+```
+Cron (daily 08:00 UTC)
+   │
+   ▼
+handleScheduled()   ──────►  runDailyPoll(env, { skipDispatch: false })
+                                  │
+POST /admin/api/refresh-gsc   ►  runDailyPoll(env, { skipDispatch: true })
+                                  │
+                                  ▼
+                    ┌─────────────────────────┐
+                    │   GSCClient (jwt.ts +   │
+                    │   gsc.ts)               │
+                    │   - sitemaps.list       │
+                    │   - searchanalytics.query│
+                    │   - sites.list (debug)  │
+                    └────────────┬────────────┘
+                                  │
+                                  ▼
+                    ┌─────────────────────────┐
+                    │   resolveAlerts(...)    │
+                    │   pure fn               │
+                    │                         │
+                    │   state machine:        │
+                    │   not-seen → pending    │
+                    │   pending → alert       │
+                    │   alert → alert (cont.) │
+                    │   any → drop (resolved) │
+                    └────────────┬────────────┘
+                                  │
+                                  ▼
+                    ┌─────────────────────────┐
+                    │   dispatchAlerts (when  │
+                    │   !skipDispatch):       │
+                    │                         │
+                    │   notifier.sendAlert()  │
+                    │    CF → Resend fallback │
+                    │   + 24h KV dedup        │
+                    └────────────┬────────────┘
+                                  │
+                                  ▼
+                         GSC_KV
+                         - status:latest
+                         - status:history:YYYY-MM-DD (35d TTL)
+                         - alert:dedup:{type}:{discriminator} (24h TTL)
+                                  │
+                                  ▼
+GET /admin/api/gsc-status    ────►  gsc-widget.js renders widget
+```
+
+## Files
+
+### Source
+
+- **`src/jwt.ts`** — RS256 JWT signing via Web Crypto's `SubtleCrypto`. PEM → PKCS#8 binary → signed assertion.
+- **`src/gsc.ts`** — GSC API client. Service-account auth, in-invocation token cache, typed method per endpoint.
+- **`src/notifier.ts`** — Email abstraction. `sendAlert(env, {subject, body})` tries `env.SEND_EMAIL` first, falls back to Resend on any failure. `buildMimeMessage` sanitises CR/LF in header fields.
+- **`src/scheduled.ts`** — Orchestrator. `runDailyPoll` does the full cycle; `resolveAlerts` is the pure-function core; `handleScheduled` is the cron entry point (wraps in `ctx.waitUntil`).
+- **`src/gscHelpers.ts`** — Pure helpers: `sanitiseUpstreamError` (caps + strips multi-line errors), `mergeEmailDelivery` (dedup-aware state merger).
+- **`src/gscWidgetViewModel.ts`** — Pure `renderViewModel(snapshot, now)` that flattens a snapshot into the shape the DOM renderer consumes. Fully unit-testable.
+- **`src/lint.ts`** — Pre-publish lint rules. Pure functions, no I/O.
+- **`src/routes/gscDebug.ts`** — `GET /admin/api/gsc-debug`. Auth-gated smoke-test; lists sites + sitemaps. Use post-secret-rotation or after deploy to verify credentials.
+- **`src/routes/gscStatus.ts`** — `GET /admin/api/gsc-status`. Auth-gated. Returns `{ok, snapshot}` from `status:latest` for the widget.
+- **`src/routes/refreshGsc.ts`** — `POST /admin/api/refresh-gsc`. Auth-gated, rate-limited (1/60s), CSRF-checked. Calls `runDailyPoll` with `skipDispatch: true`.
+- **`public/admin/gsc-widget.js`** — Client-side DOM renderer. Mirrors the view-model transformation from `gscWidgetViewModel.ts`.
+
+### Config
+
+- **`wrangler.toml`** — `[[kv_namespaces]] GSC_KV`, `[[send_email]] SEND_EMAIL`, `[triggers] crons = ["0 8 * * *"]`.
+- **`.dev.vars.example`** — documents `GSC_SERVICE_ACCOUNT_JSON` secret.
+
+## Key data shapes
+
+See [`src/types.ts`](../src/types.ts):
+
+- **`GSCSnapshot`** — one daily sample. Persisted to `status:latest` and `status:history:YYYY-MM-DD`.
+- **`GSCAlert`** — a graduated/continuing alert; carries `firstDetectedAt` (preserved through state transitions) and `detectedAt` (this run's observation time).
+- **`GSCPendingAlert`** — a first-observed condition that hasn't graduated yet.
+- **`GSCEmailDelivery`** — `lastProvider` is `null` (never tried), `'cf'` / `'resend'` (success via that provider), or `'none'` (both failed).
+
+## Alert thresholds (current, tunable)
+
+Defined as constants in `src/scheduled.ts`:
+
+| Alert type | Trigger | Severity |
+|---|---|---|
+| `indexed-drop` | current < 80% of 7-day-ago indexed count | high |
+| `sitemap-error` | any sitemap reports errors > 0 | high |
+| `new-crawl-warning` | current total warnings > previous snapshot's total | medium |
+| `impressions-drop` | current 28d impressions < 50% of prior 28d | medium |
+
+All drop alerts use **two-consecutive-observation graduation** — first observation marks `pending`, second fires the real alert. Reduces false positives from GSC's 1–2 day data lag.
+
+Dedup: 24h per alert type. See [issue #31](https://github.com/mannepanne/hultberg-org/issues/31) for threshold tuning plans once ~30 days of data accumulate.
+
+## Email delivery
+
+Alerts use `sendAlert` in `src/notifier.ts`:
+
+1. Try `env.SEND_EMAIL.send(new EmailMessage(from, to, mimeString))` — Cloudflare Email Sending (beta).
+2. If it throws or the binding is absent, fall back to Resend (`sendViaResend` in `src/email.ts`).
+3. Log which path was used for delivery-reliability telemetry.
+
+**Magic-link auth emails do NOT use this path.** They call `sendViaResend` directly, to keep auth on a stable proven provider until CF Email Sending is GA. See the [CF Email Sending ADR](./decisions/2026-04-18-cf-email-sending-with-resend-fallback.md) for re-evaluation triggers.
+
+## Ops tasks
+
+### Smoke-test credentials
+
+```
+GET /admin/api/gsc-debug
+```
+
+(signed in as admin, in a browser). Returns sites + sitemap status. Use this after any of:
+- Deploy that touched `src/jwt.ts`, `src/gsc.ts`, or the wrangler service-account secret
+- Rotating the service-account key
+- Adding/removing the service account from GSC properties
+
+### Rotate the service-account key
+
+1. In Google Cloud Console → IAM → Service Accounts → hultberg-org-search-console → Keys → Add Key → Create new key (JSON).
+2. Save the new JSON outside the repo (e.g. `~/Documents/secrets/hultberg-gsc-YYYY-MM-DD.json`, chmod 600).
+3. `npx wrangler secret put GSC_SERVICE_ACCOUNT_JSON < path/to/new.json` — pipes the new JSON into the Worker secret.
+4. Hit `/admin/api/gsc-debug` to confirm the new key works.
+5. Delete the old key in Google Cloud Console.
+
+### Trigger a manual refresh
+
+Either click the **Refresh** button on `/admin/dashboard`, or `POST /admin/api/refresh-gsc` directly. Refresh computes + persists the snapshot but does **not** send emails or write dedup keys — email is cron-only.
+
+### Add a new alert type
+
+1. Add the literal to `GSCAlertType` in `src/types.ts`.
+2. Add a case in `resolveAlerts` (`src/scheduled.ts`) that pushes a condition with `type`, `severity`, `subject`, `message`, optional `discriminator`.
+3. If it needs unit test coverage, extend `tests/unit/scheduled-resolveAlerts.test.ts`.
+4. Update this doc's threshold table.
+5. Consider whether the alert's trust-surface implications require an ADR amendment (see [issue #33](https://github.com/mannepanne/hultberg-org/issues/33)).
+
+### Manual actions & security issues
+
+**Not API-accessible.** The GSC v1 API does not expose `manualActions` or `securityIssues` resources. Google emails the verified property owner directly when these occur. The dashboard widget surfaces a "Check Search Console" reminder link — Magnus should visit Search Console directly to review these if prompted by Google's email.
+
+## Known gaps / follow-up issues
+
+- [#30](https://github.com/mannepanne/hultberg-org/issues/30) — Email body enrichment (top queries, deep-links, re-fire tags)
+- [#31](https://github.com/mannepanne/hultberg-org/issues/31) — Threshold tuning after 30 days of data
+- [#33](https://github.com/mannepanne/hultberg-org/issues/33) — CF Email Sending ADR trust-surface note
+
+## Testing strategy
+
+- **Unit**: `jwt.test.ts`, `gsc.test.ts`, `gscHelpers.test.ts`, `lint.test.ts`, `notifier.test.ts`, `gscWidgetViewModel.test.ts`, `scheduled-resolveAlerts.test.ts`. Pure-function surface; no I/O.
+- **Integration**: `scheduled.test.ts`, `gscStatus.test.ts`, `refreshGsc.test.ts`. End-to-end orchestrator behaviour with mocked GSC API + KV.
+- **Workerd runtime**: not exercised in CI (Vitest runs under Node). The `gsc-debug` endpoint is the de-facto post-deploy smoke test — **do not remove it without adding a miniflare/workerd-runner JWT round-trip test**.

--- a/SPECIFICATIONS/ARCHIVE/gsc-insights-and-alerts.md
+++ b/SPECIFICATIONS/ARCHIVE/gsc-insights-and-alerts.md
@@ -1,8 +1,10 @@
 # GSC Insights & Alerts (Layer 1)
 
-**Status:** 📝 Draft — pending review
+**Status:** ✅ Complete
 **Created:** 2026-04-18
+**Completed:** 2026-04-18 (PR #29 plumbing, PR 2 UI + lint)
 **Depends on:** `/sitemap.xml` route (PR #27, merged 2026-04-18)
+**How-it-works doc:** [REFERENCE/gsc-insights.md](../../REFERENCE/gsc-insights.md)
 
 ## Overview
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,62 @@
         "@cloudflare/workers-types": "^4.20250628.0",
         "@types/node": "^25.2.3",
         "@vitest/coverage-v8": "^4.0.18",
+        "jsdom": "^29.0.2",
         "typescript": "^5.8.3",
         "vitest": "^4.0.18",
         "wrangler": "^4.22.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -79,6 +131,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -212,6 +277,146 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -665,6 +870,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -1714,6 +1937,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -1786,6 +2019,41 @@
         "node": ">=18"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/defu": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
@@ -1801,6 +2069,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-stack-parser-es": {
@@ -1951,6 +2232,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -1962,6 +2256,13 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2024,6 +2325,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -2032,6 +2384,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/magic-string": {
@@ -2083,6 +2445,13 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mime": {
       "version": "3.0.0",
@@ -2160,6 +2529,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -2223,6 +2605,26 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -2266,6 +2668,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.57.1",
         "@rollup/rollup-win32-x64-msvc": "4.57.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -2386,6 +2801,13 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2428,6 +2850,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -3110,6 +3578,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3217,6 +3733,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/youch": {
       "version": "4.1.0-beta.10",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@cloudflare/workers-types": "^4.20250628.0",
     "@types/node": "^25.2.3",
     "@vitest/coverage-v8": "^4.0.18",
+    "jsdom": "^29.0.2",
     "typescript": "^5.8.3",
     "vitest": "^4.0.18",
     "wrangler": "^4.22.0"

--- a/public/admin/gsc-widget.js
+++ b/public/admin/gsc-widget.js
@@ -1,0 +1,234 @@
+// ABOUT: Client-side renderer for the GSC Search-visibility widget.
+// ABOUT: Fetches /admin/api/gsc-status and renders into #gsc-widget-root.
+// ABOUT: The view-model transformation lives server-side in src/gscWidgetViewModel.ts
+// ABOUT: and is executed by the backend; this script only handles DOM mutation
+// ABOUT: and user interaction (refresh button).
+
+(function () {
+  'use strict';
+
+  const ROOT_ID = 'gsc-widget-root';
+  const PROPERTY_URL = 'sc-domain:hultberg.org';
+  const GSC_CONSOLE_LINK = 'https://search.google.com/search-console?resource_id=' + encodeURIComponent(PROPERTY_URL);
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  function render(vm) {
+    return `
+      <section class="widget" aria-label="Search visibility">
+        <div class="widget-header">
+          <h2>Search visibility (<a href="${GSC_CONSOLE_LINK}" target="_blank" rel="noopener">GSC</a>)</h2>
+          <span class="freshness ${vm.state === 'stale' ? 'stale' : ''}">${escapeHtml(vm.freshnessLabel)}</span>
+          <button class="refresh" type="button" id="gsc-refresh-btn">↻ Refresh</button>
+        </div>
+        ${renderAlerts(vm.alerts)}
+        ${vm.kpis.length > 0 ? renderKpis(vm.kpis) : ''}
+        ${vm.topQueries.length > 0 ? renderQueries(vm.topQueries) : ''}
+        ${renderFooter(vm)}
+      </section>
+    `;
+  }
+
+  function renderAlerts(alerts) {
+    if (alerts.length === 0) return '';
+    const items = alerts.map((a) => `
+      <div class="alert ${escapeHtml(a.severity)}">
+        <span class="icon">${a.severity === 'high' ? '🔴' : '⚠️'}</span>
+        <div class="body">
+          <div class="title">${escapeHtml(a.subject)}</div>
+          <div class="meta">${escapeHtml(a.message)} Seen for ${a.daysSeen} ${a.daysSeen === 1 ? 'day' : 'days'}.${a.emailSent ? ' Email sent.' : ''}</div>
+        </div>
+      </div>
+    `).join('');
+    return `<div class="alerts">${items}</div>`;
+  }
+
+  function renderKpis(kpis) {
+    const tiles = kpis.map((k) => `
+      <div class="tile">
+        <div class="label">${escapeHtml(k.label)}</div>
+        <div class="value">${escapeHtml(k.value)}</div>
+        <div class="sub ${k.deltaClass !== 'flat' ? 'delta ' + escapeHtml(k.deltaClass) : ''}">${escapeHtml(k.sub)}</div>
+      </div>
+    `).join('');
+    return `<div class="tiles">${tiles}</div>`;
+  }
+
+  function renderQueries(queries) {
+    const rows = queries.map((q) => `
+      <tr>
+        <td class="query">${escapeHtml(q.query)}</td>
+        <td class="metrics">
+          <span class="clicks">${q.clicks}</span>
+          ${q.impressions.toLocaleString()} impr · ${escapeHtml(q.ctrPct)} CTR · pos ${escapeHtml(q.position)}
+        </td>
+      </tr>
+    `).join('');
+    return `
+      <div class="queries">
+        <h3>Top queries · last 28 days</h3>
+        <table>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  function renderFooter(vm) {
+    const delivery = vm.emailDelivery;
+    return `
+      <div class="gsc-footer">
+        <span class="email-delivery ${escapeHtml(delivery.kind)}">Email delivery: ${escapeHtml(delivery.label)}</span>
+        <span class="manual-check">Manual actions &amp; security issues aren't in the GSC API — Google emails you directly. <a href="https://search.google.com/search-console/manual-actions" target="_blank" rel="noopener">Check Search Console ↗</a></span>
+      </div>
+    `;
+  }
+
+  function renderLoading() {
+    return '<section class="widget" aria-label="Search visibility"><div class="widget-body"><em>Loading search visibility…</em></div></section>';
+  }
+
+  function renderError(message) {
+    return `<section class="widget" aria-label="Search visibility"><div class="widget-body error">Failed to load: ${escapeHtml(message)}</div></section>`;
+  }
+
+  async function fetchViewModel() {
+    const response = await fetch('/admin/api/gsc-status', { credentials: 'same-origin' });
+    if (!response.ok) {
+      throw new Error('Status API returned ' + response.status);
+    }
+    const body = await response.json();
+    if (!body.ok) {
+      throw new Error(body.error || 'Unknown error');
+    }
+    return computeViewModel(body.snapshot, new Date());
+  }
+
+  // Mirror of src/gscWidgetViewModel.ts. Duplicated here because the worker
+  // sends the raw snapshot (smaller payload + no server-side date baked in)
+  // and the client computes the view with its own "now". Tests cover the
+  // server-side copy; behaviour must match.
+  function computeViewModel(snapshot, now) {
+    if (!snapshot) {
+      return {
+        state: 'empty',
+        freshnessLabel: 'No data yet — the first poll runs daily at 08:00 UTC.',
+        alerts: [],
+        kpis: [],
+        topQueries: [],
+        emailDelivery: { label: 'Never attempted', kind: 'idle' },
+      };
+    }
+    const ageHours = Math.max(0, Math.floor((now - new Date(snapshot.capturedAt)) / 3600000));
+    const isStale = ageHours >= 36;
+    return {
+      state: isStale ? 'stale' : 'fresh',
+      freshnessLabel: freshnessLabel(ageHours),
+      alerts: snapshot.alerts.map((a) => ({
+        type: a.type, severity: a.severity, subject: a.subject, message: a.message,
+        firstDetectedAt: a.firstDetectedAt,
+        daysSeen: Math.max(1, Math.floor((now - new Date(a.firstDetectedAt)) / 86400000) + 1),
+        emailSent: a.emailSent,
+      })),
+      kpis: buildKpis(snapshot),
+      topQueries: snapshot.performance.topQueries.map((q) => ({
+        query: q.query, clicks: q.clicks, impressions: q.impressions,
+        ctrPct: (q.ctr * 100).toFixed(1) + '%',
+        position: q.position.toFixed(1),
+      })),
+      emailDelivery: buildEmailDelivery(snapshot, now),
+    };
+  }
+
+  function freshnessLabel(hours) {
+    if (hours === 0) return 'Refreshed moments ago';
+    if (hours === 1) return 'Refreshed 1 hour ago';
+    if (hours < 24) return 'Refreshed ' + hours + ' hours ago';
+    const days = Math.floor(hours / 24);
+    return days === 1 ? 'Refreshed 1 day ago' : 'Refreshed ' + days + ' days ago';
+  }
+
+  function buildKpis(snapshot) {
+    const sm = snapshot.sitemaps[0];
+    const submitted = sm ? sm.submitted : 0;
+    const indexed = sm ? sm.indexed : 0;
+    const perf = snapshot.performance;
+    const clicksDelta = perf.priorPeriodClicks > 0 ? (perf.totalClicks - perf.priorPeriodClicks) / perf.priorPeriodClicks : 0;
+    const imprDelta = perf.priorPeriodImpressions > 0 ? (perf.totalImpressions - perf.priorPeriodImpressions) / perf.priorPeriodImpressions : 0;
+    const deltaClass = (d) => d > 0.02 ? 'up' : d < -0.02 ? 'down' : 'flat';
+    const fmt = (d) => d === 0 ? 'no change vs prior 28d' : ((d > 0 ? '+' : '') + Math.round(d * 100) + '% vs prior 28d');
+    return [
+      { label: 'Indexed pages', value: String(snapshot.indexing.indexedCount), sub: '', deltaClass: 'flat' },
+      { label: 'Sitemap', value: submitted === 0 ? '0' : (indexed + ' / ' + submitted), sub: 'indexed / submitted', deltaClass: 'flat' },
+      { label: 'Clicks (28d)', value: String(perf.totalClicks), sub: fmt(clicksDelta), deltaClass: deltaClass(clicksDelta) },
+      { label: 'Impressions (28d)', value: String(perf.totalImpressions), sub: fmt(imprDelta), deltaClass: deltaClass(imprDelta) },
+    ];
+  }
+
+  function buildEmailDelivery(snapshot, now) {
+    const d = snapshot.emailDelivery;
+    if (!d.lastProvider && !d.lastSuccessAt && !d.lastErrorAt) {
+      return { label: 'Never attempted', kind: 'idle' };
+    }
+    const rel = (iso) => {
+      if (!iso) return 'recently';
+      const h = Math.max(0, Math.floor((now - new Date(iso)) / 3600000));
+      if (h < 1) return 'just now';
+      if (h === 1) return '1h ago';
+      if (h < 24) return h + 'h ago';
+      const days = Math.floor(h / 24);
+      return days === 1 ? '1d ago' : days + 'd ago';
+    };
+    if (d.lastProvider === 'none') return { label: 'Both providers failed · ' + rel(d.lastErrorAt), kind: 'error' };
+    if (d.lastProvider === 'resend') return { label: 'Resend (fallback) · ' + rel(d.lastSuccessAt), kind: 'warn' };
+    if (d.lastProvider === 'cf') return { label: 'CF · ' + rel(d.lastSuccessAt), kind: 'ok' };
+    return { label: 'Never attempted', kind: 'idle' };
+  }
+
+  async function doRefresh() {
+    const btn = document.getElementById('gsc-refresh-btn');
+    if (btn) { btn.disabled = true; btn.textContent = 'Refreshing…'; }
+    try {
+      const response = await fetch('/admin/api/refresh-gsc', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error || ('Refresh failed: ' + response.status));
+      }
+      await load();
+    } catch (err) {
+      const root = document.getElementById(ROOT_ID);
+      if (root) root.innerHTML = renderError(err.message);
+    }
+  }
+
+  async function load() {
+    const root = document.getElementById(ROOT_ID);
+    if (!root) return;
+    root.innerHTML = renderLoading();
+    try {
+      const vm = await fetchViewModel();
+      root.innerHTML = render(vm);
+      const btn = document.getElementById('gsc-refresh-btn');
+      if (btn) btn.addEventListener('click', doRefresh);
+    } catch (err) {
+      root.innerHTML = renderError(err.message);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', load);
+  } else {
+    load();
+  }
+})();

--- a/public/admin/gsc-widget.js
+++ b/public/admin/gsc-widget.js
@@ -21,11 +21,17 @@
   }
 
   function render(vm) {
+    var freshnessAria = vm.state === 'stale'
+      ? 'aria-label="Stale: ' + escapeHtml(vm.freshnessLabel) + '"'
+      : '';
+    var freshnessText = vm.state === 'stale'
+      ? 'Stale · ' + escapeHtml(vm.freshnessLabel)
+      : escapeHtml(vm.freshnessLabel);
     return `
       <section class="widget" aria-label="Search visibility">
         <div class="widget-header">
           <h2>Search visibility (<a href="${GSC_CONSOLE_LINK}" target="_blank" rel="noopener">GSC</a>)</h2>
-          <span class="freshness ${vm.state === 'stale' ? 'stale' : ''}">${escapeHtml(vm.freshnessLabel)}</span>
+          <span class="freshness ${vm.state === 'stale' ? 'stale' : ''}" ${freshnessAria}>${freshnessText}</span>
           <button class="refresh" type="button" id="gsc-refresh-btn">↻ Refresh</button>
         </div>
         ${renderAlerts(vm.alerts)}
@@ -131,12 +137,17 @@
     return {
       state: isStale ? 'stale' : 'fresh',
       freshnessLabel: freshnessLabel(ageHours),
-      alerts: snapshot.alerts.map((a) => ({
-        type: a.type, severity: a.severity, subject: a.subject, message: a.message,
-        firstDetectedAt: a.firstDetectedAt,
-        daysSeen: Math.max(1, Math.floor((now - new Date(a.firstDetectedAt)) / 86400000) + 1),
-        emailSent: a.emailSent,
-      })),
+      alerts: snapshot.alerts.map(function (a) {
+        // Back-compat: alerts written by PR #29's cron lack firstDetectedAt.
+        // Mirrors the fallback in src/gscWidgetViewModel.ts.
+        var firstDetectedAt = a.firstDetectedAt || a.detectedAt || snapshot.capturedAt;
+        return {
+          type: a.type, severity: a.severity, subject: a.subject, message: a.message,
+          firstDetectedAt: firstDetectedAt,
+          daysSeen: Math.max(1, Math.floor((now - new Date(firstDetectedAt)) / 86400000) + 1),
+          emailSent: a.emailSent,
+        };
+      }),
       kpis: buildKpis(snapshot),
       topQueries: snapshot.performance.topQueries.map((q) => ({
         query: q.query, clicks: q.clicks, impressions: q.impressions,
@@ -195,6 +206,7 @@
   async function doRefresh() {
     const btn = document.getElementById('gsc-refresh-btn');
     if (btn) { btn.disabled = true; btn.textContent = 'Refreshing…'; }
+    clearRefreshError();
     try {
       const response = await fetch('/admin/api/refresh-gsc', {
         method: 'POST',
@@ -202,14 +214,46 @@
         headers: { 'Content-Type': 'application/json' },
       });
       if (!response.ok) {
-        const body = await response.json().catch(() => ({}));
+        const body = await response.json().catch(function () { return {}; });
         throw new Error(body.error || ('Refresh failed: ' + response.status));
       }
       await load();
     } catch (err) {
-      const root = document.getElementById(ROOT_ID);
-      if (root) root.innerHTML = renderError(err.message);
+      // Non-destructive: show error as a banner ABOVE the widget header.
+      // The widget content (alerts, KPIs, queries) stays intact and the
+      // refresh button is restored so the user can try again. Critically,
+      // the 429 rate-limit case (which is *expected* behaviour) doesn't
+      // destroy the UI.
+      showRefreshError(err.message);
+      restoreRefreshButton();
     }
+  }
+
+  function showRefreshError(message) {
+    var widget = document.querySelector('#' + ROOT_ID + ' .widget');
+    if (!widget) return;
+    var existing = document.getElementById('gsc-refresh-error');
+    if (existing) existing.remove();
+    var banner = document.createElement('div');
+    banner.id = 'gsc-refresh-error';
+    banner.className = 'refresh-error';
+    banner.setAttribute('role', 'alert');
+    banner.innerHTML =
+      '<span class="msg">Refresh failed: ' + escapeHtml(message) + '</span>' +
+      '<button type="button" class="dismiss" aria-label="Dismiss">×</button>';
+    widget.insertBefore(banner, widget.firstChild);
+    var dismissBtn = banner.querySelector('.dismiss');
+    if (dismissBtn) dismissBtn.addEventListener('click', clearRefreshError);
+  }
+
+  function clearRefreshError() {
+    var existing = document.getElementById('gsc-refresh-error');
+    if (existing) existing.remove();
+  }
+
+  function restoreRefreshButton() {
+    var btn = document.getElementById('gsc-refresh-btn');
+    if (btn) { btn.disabled = false; btn.textContent = '↻ Refresh'; }
   }
 
   async function load() {

--- a/public/admin/gsc-widget.js
+++ b/public/admin/gsc-widget.js
@@ -21,6 +21,11 @@
   }
 
   function render(vm) {
+    // freshnessAria is a pre-built attribute string interpolated raw into the
+    // template literal below. Safe because vm.freshnessLabel is integer-derived
+    // (computed from age in hours/days) and we still escape it. If you ever
+    // route attacker-influenced content through here, escape at the *value*
+    // boundary AND verify the attribute syntax can't be broken out of.
     var freshnessAria = vm.state === 'stale'
       ? 'aria-label="Stale: ' + escapeHtml(vm.freshnessLabel) + '"'
       : '';
@@ -139,7 +144,10 @@
       freshnessLabel: freshnessLabel(ageHours),
       alerts: snapshot.alerts.map(function (a) {
         // Back-compat: alerts written by PR #29's cron lack firstDetectedAt.
-        // Mirrors the fallback in src/gscWidgetViewModel.ts.
+        // Mirrors the fallback in src/gscWidgetViewModel.ts (which uses ??).
+        // We use || here intentionally — also catches accidentally-empty-string
+        // values (which `??` would let through and then `new Date('')` would
+        // produce Invalid Date).
         var firstDetectedAt = a.firstDetectedAt || a.detectedAt || snapshot.capturedAt;
         return {
           type: a.type, severity: a.severity, subject: a.subject, message: a.message,

--- a/public/admin/gsc-widget.js
+++ b/public/admin/gsc-widget.js
@@ -278,7 +278,19 @@
     }
   }
 
-  if (document.readyState === 'loading') {
+  // Test hook: a JSDOM test sets `window.__gscWidgetTest = {}` BEFORE this
+  // script runs, then reads `window.__gscWidgetTest.api` to invoke individual
+  // helpers. Production browsers never set this, so the auto-load runs as
+  // normal. The reference is harmless either way.
+  if (typeof window !== 'undefined' && window.__gscWidgetTest) {
+    window.__gscWidgetTest.api = {
+      escapeHtml: escapeHtml,
+      showRefreshError: showRefreshError,
+      clearRefreshError: clearRefreshError,
+      restoreRefreshButton: restoreRefreshButton,
+      computeViewModel: computeViewModel,
+    };
+  } else if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', load);
   } else {
     load();

--- a/src/gscWidgetViewModel.ts
+++ b/src/gscWidgetViewModel.ts
@@ -66,15 +66,21 @@ export function renderViewModel(snapshot: GSCSnapshot | null, now: Date): Widget
   return {
     state: isStale ? 'stale' : 'fresh',
     freshnessLabel: freshnessLabel(ageHours),
-    alerts: snapshot.alerts.map((a) => ({
-      type: a.type,
-      severity: a.severity,
-      subject: a.subject,
-      message: a.message,
-      firstDetectedAt: a.firstDetectedAt,
-      daysSeen: daysBetween(new Date(a.firstDetectedAt), now),
-      emailSent: a.emailSent,
-    })),
+    alerts: snapshot.alerts.map((a) => {
+      // Back-compat: alerts written by PR #29's cron lack firstDetectedAt.
+      // Fall back to detectedAt, then to the snapshot's own capture time —
+      // anything but `undefined`, which would render as "Seen for NaN days".
+      const firstDetectedAt = a.firstDetectedAt ?? a.detectedAt ?? snapshot.capturedAt;
+      return {
+        type: a.type,
+        severity: a.severity,
+        subject: a.subject,
+        message: a.message,
+        firstDetectedAt,
+        daysSeen: daysBetween(new Date(firstDetectedAt), now),
+        emailSent: a.emailSent,
+      };
+    }),
     kpis: buildKpis(snapshot),
     topQueries: snapshot.performance.topQueries.map((q) => ({
       query: q.query,

--- a/src/gscWidgetViewModel.ts
+++ b/src/gscWidgetViewModel.ts
@@ -1,0 +1,187 @@
+// ABOUT: Pure transformation from a GSCSnapshot into a flat view-model for the
+// ABOUT: dashboard widget. Keeping the DOM-free half separate means the bulk of
+// ABOUT: the widget's logic is unit-testable in the Node test runtime.
+
+import type { GSCSnapshot } from './types';
+
+export interface WidgetAlert {
+  type: string;
+  severity: 'high' | 'medium';
+  subject: string;
+  message: string;
+  firstDetectedAt: string;
+  daysSeen: number;
+  emailSent: boolean;
+}
+
+export interface WidgetKpiTile {
+  label: string;
+  value: string;
+  sub: string;
+  deltaClass: 'up' | 'down' | 'flat';
+}
+
+export interface WidgetTopQuery {
+  query: string;
+  clicks: number;
+  impressions: number;
+  ctrPct: string;     // pre-formatted, e.g. "4.5%"
+  position: string;   // pre-formatted, e.g. "2.1"
+}
+
+export interface WidgetViewModel {
+  state: 'empty' | 'stale' | 'fresh';
+  freshnessLabel: string;      // "Last refreshed 4h ago" or "No data yet"
+  alerts: WidgetAlert[];
+  kpis: WidgetKpiTile[];
+  topQueries: WidgetTopQuery[];
+  emailDelivery: {
+    label: string;             // "CF · 2h ago" / "Resend (fallback) · 1d ago" / "Never attempted" / "Both providers failed · Xh ago"
+    kind: 'ok' | 'warn' | 'error' | 'idle';
+  };
+}
+
+const STALE_HOURS = 36;
+
+/**
+ * Build a view-model from a snapshot + current time.
+ * If snapshot is null (no data yet), returns the empty state.
+ */
+export function renderViewModel(snapshot: GSCSnapshot | null, now: Date): WidgetViewModel {
+  if (!snapshot) {
+    return {
+      state: 'empty',
+      freshnessLabel: 'No data yet — the first poll runs daily at 08:00 UTC.',
+      alerts: [],
+      kpis: [],
+      topQueries: [],
+      emailDelivery: { label: 'Never attempted', kind: 'idle' },
+    };
+  }
+
+  const ageMs = now.getTime() - new Date(snapshot.capturedAt).getTime();
+  const ageHours = Math.max(0, Math.floor(ageMs / (60 * 60 * 1000)));
+  const isStale = ageHours >= STALE_HOURS;
+
+  return {
+    state: isStale ? 'stale' : 'fresh',
+    freshnessLabel: freshnessLabel(ageHours),
+    alerts: snapshot.alerts.map((a) => ({
+      type: a.type,
+      severity: a.severity,
+      subject: a.subject,
+      message: a.message,
+      firstDetectedAt: a.firstDetectedAt,
+      daysSeen: daysBetween(new Date(a.firstDetectedAt), now),
+      emailSent: a.emailSent,
+    })),
+    kpis: buildKpis(snapshot),
+    topQueries: snapshot.performance.topQueries.map((q) => ({
+      query: q.query,
+      clicks: q.clicks,
+      impressions: q.impressions,
+      ctrPct: `${(q.ctr * 100).toFixed(1)}%`,
+      position: q.position.toFixed(1),
+    })),
+    emailDelivery: buildEmailDelivery(snapshot, now),
+  };
+}
+
+function freshnessLabel(ageHours: number): string {
+  if (ageHours === 0) return 'Refreshed moments ago';
+  if (ageHours === 1) return 'Refreshed 1 hour ago';
+  if (ageHours < 24) return `Refreshed ${ageHours} hours ago`;
+  const days = Math.floor(ageHours / 24);
+  return days === 1 ? 'Refreshed 1 day ago' : `Refreshed ${days} days ago`;
+}
+
+function daysBetween(from: Date, to: Date): number {
+  const ms = to.getTime() - from.getTime();
+  return Math.max(1, Math.floor(ms / (24 * 60 * 60 * 1000)) + 1);
+}
+
+function buildKpis(snapshot: GSCSnapshot): WidgetKpiTile[] {
+  const sitemap = snapshot.sitemaps[0];
+  const submitted = sitemap?.submitted ?? 0;
+  const indexed = sitemap?.indexed ?? 0;
+
+  const clicksDelta = snapshot.performance.priorPeriodClicks > 0
+    ? (snapshot.performance.totalClicks - snapshot.performance.priorPeriodClicks) / snapshot.performance.priorPeriodClicks
+    : 0;
+  const impressionsDelta = snapshot.performance.priorPeriodImpressions > 0
+    ? (snapshot.performance.totalImpressions - snapshot.performance.priorPeriodImpressions) / snapshot.performance.priorPeriodImpressions
+    : 0;
+
+  return [
+    {
+      label: 'Indexed pages',
+      value: String(snapshot.indexing.indexedCount),
+      sub: '',
+      deltaClass: 'flat',
+    },
+    {
+      label: 'Sitemap',
+      value: submitted === 0 ? '0' : `${indexed} / ${submitted}`,
+      sub: 'indexed / submitted',
+      deltaClass: 'flat',
+    },
+    {
+      label: 'Clicks (28d)',
+      value: String(snapshot.performance.totalClicks),
+      sub: formatDeltaSub(clicksDelta, 'vs prior 28d'),
+      deltaClass: deltaClassFor(clicksDelta),
+    },
+    {
+      label: 'Impressions (28d)',
+      value: String(snapshot.performance.totalImpressions),
+      sub: formatDeltaSub(impressionsDelta, 'vs prior 28d'),
+      deltaClass: deltaClassFor(impressionsDelta),
+    },
+  ];
+}
+
+function formatDeltaSub(delta: number, suffix: string): string {
+  if (delta === 0) return `no change ${suffix}`;
+  const pct = Math.round(delta * 100);
+  const sign = pct > 0 ? '+' : '';
+  return `${sign}${pct}% ${suffix}`;
+}
+
+function deltaClassFor(delta: number): 'up' | 'down' | 'flat' {
+  if (delta > 0.02) return 'up';
+  if (delta < -0.02) return 'down';
+  return 'flat';
+}
+
+function buildEmailDelivery(snapshot: GSCSnapshot, now: Date): WidgetViewModel['emailDelivery'] {
+  const d = snapshot.emailDelivery;
+  if (!d.lastProvider && !d.lastSuccessAt && !d.lastErrorAt) {
+    return { label: 'Never attempted', kind: 'idle' };
+  }
+
+  if (d.lastProvider === 'none') {
+    const age = d.lastErrorAt ? relativeTimeLabel(new Date(d.lastErrorAt), now) : 'recently';
+    return { label: `Both providers failed · ${age}`, kind: 'error' };
+  }
+
+  if (d.lastProvider === 'resend') {
+    const age = d.lastSuccessAt ? relativeTimeLabel(new Date(d.lastSuccessAt), now) : 'recently';
+    return { label: `Resend (fallback) · ${age}`, kind: 'warn' };
+  }
+
+  if (d.lastProvider === 'cf') {
+    const age = d.lastSuccessAt ? relativeTimeLabel(new Date(d.lastSuccessAt), now) : 'recently';
+    return { label: `CF · ${age}`, kind: 'ok' };
+  }
+
+  return { label: 'Never attempted', kind: 'idle' };
+}
+
+function relativeTimeLabel(from: Date, now: Date): string {
+  const hours = Math.max(0, Math.floor((now.getTime() - from.getTime()) / (60 * 60 * 1000)));
+  if (hours < 1) return 'just now';
+  if (hours === 1) return '1h ago';
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return days === 1 ? '1d ago' : `${days}d ago`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import { handleUpdatePage } from './routes/updatePage';
 import { handleRSSFeed } from './routes/rssFeed';
 import { handleSitemap } from './routes/sitemap';
 import { handleGscDebug } from './routes/gscDebug';
+import { handleGscStatus } from './routes/gscStatus';
+import { handleRefreshGsc } from './routes/refreshGsc';
 import { handleScheduled } from './scheduled';
 import { handleAdminLogin } from './routes/adminLogin';
 import { handleAdminLogout } from './routes/adminLogout';
@@ -107,6 +109,19 @@ export default {
     // Smoke-tests the GSC service account credentials — lists sites + sitemaps.
     if (url.pathname === '/admin/api/gsc-debug' && request.method === 'GET') {
       return handleGscDebug(request, env);
+    }
+
+    // API: GET /admin/api/gsc-status (authenticated)
+    // Returns the latest GSC snapshot from KV for the dashboard widget.
+    if (url.pathname === '/admin/api/gsc-status' && request.method === 'GET') {
+      return handleGscStatus(request, env);
+    }
+
+    // API: POST /admin/api/refresh-gsc (authenticated, rate-limited)
+    // Manually re-runs the GSC poll. Skips email dispatch — cron is the only
+    // delivery path. Used by the dashboard "Refresh" button.
+    if (url.pathname === '/admin/api/refresh-gsc' && request.method === 'POST') {
+      return handleRefreshGsc(request, env);
     }
 
     // Editor: GET /admin/now/edit

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,0 +1,74 @@
+// ABOUT: Pre-publish lint rules for updates. Pure functions only — no I/O.
+// ABOUT: Warnings are non-blocking; the admin editor surfaces them so Magnus
+// ABOUT: can see them but publish through them deliberately if he wants.
+
+import type { Update } from './types';
+
+export type LintRule =
+  | 'missing-excerpt'
+  | 'thin-content'
+  | 'duplicate-title'
+  | 'poor-social-preview';
+
+export interface LintWarning {
+  rule: LintRule;
+  message: string;
+}
+
+const MIN_CONTENT_CHARS = 300;
+
+export interface LintInput {
+  update: Pick<Update, 'title' | 'excerpt' | 'content' | 'images'>;
+  existingUpdates: Array<Pick<Update, 'title' | 'status' | 'slug'>>;
+  currentSlug?: string; // exclude self from the duplicate-title check
+}
+
+/**
+ * Compute lint warnings for an update being saved.
+ * Intended to run only when status is transitioning to or staying at 'published'
+ * — callers decide that; this function just applies the rules.
+ */
+export function lintUpdate(input: LintInput): LintWarning[] {
+  const warnings: LintWarning[] = [];
+  const { update } = input;
+
+  const excerpt = update.excerpt.trim();
+  const contentLength = update.content.trim().length;
+
+  if (!excerpt) {
+    warnings.push({
+      rule: 'missing-excerpt',
+      message: 'No excerpt — add one to improve SEO and social preview rendering.',
+    });
+  }
+
+  if (contentLength < MIN_CONTENT_CHARS) {
+    warnings.push({
+      rule: 'thin-content',
+      message: `Content is ${contentLength} characters — pages under ${MIN_CONTENT_CHARS} often don't get indexed.`,
+    });
+  }
+
+  const titleLower = update.title.trim().toLowerCase();
+  const duplicate = input.existingUpdates.find(
+    (u) =>
+      u.status === 'published' &&
+      u.slug !== input.currentSlug &&
+      u.title.trim().toLowerCase() === titleLower,
+  );
+  if (duplicate) {
+    warnings.push({
+      rule: 'duplicate-title',
+      message: `Title matches an existing published update (${duplicate.slug}) — consider a unique title.`,
+    });
+  }
+
+  if (update.images.length === 0 && !excerpt) {
+    warnings.push({
+      rule: 'poor-social-preview',
+      message: 'No excerpt and no images — social shares will render without context.',
+    });
+  }
+
+  return warnings;
+}

--- a/src/routes/adminDashboard.ts
+++ b/src/routes/adminDashboard.ts
@@ -151,6 +151,10 @@ function renderDashboard(email: string, updates: Update[]): string {
     .gsc-footer .email-delivery.warn { color: #856404; }
     .gsc-footer .email-delivery.error { color: #721c24; font-weight: 600; }
     .gsc-footer .email-delivery.idle { color: #6c757d; }
+    .refresh-error { display: flex; align-items: center; gap: 12px; padding: 10px 16px; background: #f8d7da; color: #721c24; border-bottom: 1px solid #f5c6cb; font-size: 0.88em; }
+    .refresh-error .msg { flex: 1; }
+    .refresh-error button.dismiss { background: transparent; border: none; color: #721c24; cursor: pointer; font-size: 1.2em; padding: 0 4px; line-height: 1; }
+    .refresh-error button.dismiss:hover { color: #491217; }
     @media (max-width: 720px) { .tiles { grid-template-columns: repeat(2, 1fr); } }
 
     table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 6px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,.1); }

--- a/src/routes/adminDashboard.ts
+++ b/src/routes/adminDashboard.ts
@@ -110,6 +110,49 @@ function renderDashboard(email: string, updates: Update[]): string {
       font-size: 0.9em;
     }
     .btn-primary:hover { background: #343a40; }
+    /* GSC widget */
+    .widget { background: #fff; border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,.1); margin-bottom: 24px; overflow: hidden; }
+    .widget-header { display: flex; align-items: center; gap: 12px; padding: 14px 20px; border-bottom: 1px solid #f1f3f5; }
+    .widget-header h2 { font-size: 1em; font-weight: 600; margin: 0; flex: 1; color: #212529; }
+    .widget-header h2 a { color: #0d6efd; text-decoration: none; }
+    .widget-header h2 a:hover { text-decoration: underline; }
+    .widget-header .freshness { font-size: 0.8em; color: #6c757d; }
+    .widget-header .freshness.stale { color: #dc3545; font-weight: 600; }
+    .widget-header button.refresh { background: transparent; border: 1px solid #dee2e6; color: #495057; padding: 4px 10px; border-radius: 4px; cursor: pointer; font-size: 0.8em; }
+    .widget-header button.refresh:hover:not(:disabled) { border-color: #adb5bd; background: #f8f9fa; }
+    .widget-header button.refresh:disabled { opacity: 0.6; cursor: wait; }
+    .widget-body { padding: 16px 20px; }
+    .widget-body.error { color: #721c24; background: #f8d7da; }
+    .alerts { padding: 0 20px; }
+    .alert { display: flex; align-items: flex-start; gap: 10px; padding: 12px 14px; border-radius: 4px; margin: 12px 0; font-size: 0.88em; }
+    .alert .icon { font-size: 1.1em; line-height: 1; }
+    .alert .body { flex: 1; }
+    .alert .body .title { font-weight: 600; color: #212529; }
+    .alert .body .meta { color: #6c757d; font-size: 0.9em; margin-top: 2px; }
+    .alert.medium { background: #fff3cd; border-left: 3px solid #ffc107; }
+    .alert.high { background: #f8d7da; border-left: 3px solid #dc3545; }
+    .tiles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; padding: 16px 20px; }
+    .tile { background: #f8f9fa; border: 1px solid #f1f3f5; border-radius: 6px; padding: 14px; }
+    .tile .label { font-size: 0.75em; text-transform: uppercase; letter-spacing: 0.05em; color: #6c757d; margin-bottom: 6px; }
+    .tile .value { font-size: 1.6em; font-weight: 700; color: #212529; line-height: 1.1; }
+    .tile .sub { font-size: 0.8em; color: #6c757d; margin-top: 4px; }
+    .tile .sub.delta.up { color: #155724; }
+    .tile .sub.delta.down { color: #721c24; }
+    .queries { padding: 4px 20px 16px; }
+    .queries h3 { font-size: 0.8em; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6c757d; margin: 12px 0 8px; }
+    .queries table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
+    .queries td { padding: 6px 0; border-top: 1px solid #f1f3f5; vertical-align: middle; }
+    .queries tr:first-child td { border-top: none; }
+    .queries td.query { color: #212529; }
+    .queries td.metrics { text-align: right; color: #6c757d; font-variant-numeric: tabular-nums; white-space: nowrap; }
+    .queries td.metrics .clicks { font-weight: 600; color: #212529; margin-right: 10px; }
+    .gsc-footer { padding: 12px 20px; font-size: 0.82em; color: #6c757d; background: #fafbfc; border-top: 1px solid #f1f3f5; display: flex; gap: 20px; flex-wrap: wrap; align-items: center; justify-content: space-between; }
+    .gsc-footer .email-delivery.ok { color: #155724; }
+    .gsc-footer .email-delivery.warn { color: #856404; }
+    .gsc-footer .email-delivery.error { color: #721c24; font-weight: 600; }
+    .gsc-footer .email-delivery.idle { color: #6c757d; }
+    @media (max-width: 720px) { .tiles { grid-template-columns: repeat(2, 1fr); } }
+
     table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 6px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
     th { background: #f1f3f5; font-size: 0.8em; text-transform: uppercase; letter-spacing: .05em; color: #6c757d; padding: 10px 14px; text-align: left; }
     td { padding: 12px 14px; border-top: 1px solid #f1f3f5; vertical-align: middle; font-size: 0.9em; }
@@ -134,6 +177,8 @@ function renderDashboard(email: string, updates: Update[]): string {
   </header>
 
   <main>
+    <div id="gsc-widget-root"></div>
+
     <div class="actions">
       <a class="btn-primary" href="/admin/updates/new">+ New Update</a>
     </div>
@@ -180,6 +225,7 @@ function renderDashboard(email: string, updates: Update[]): string {
       .catch(function() { alert('Delete failed: network error'); });
     }
   </script>
+  <script src="/admin/gsc-widget.js"></script>
 </body>
 </html>`;
 }

--- a/src/routes/adminEditor.ts
+++ b/src/routes/adminEditor.ts
@@ -85,6 +85,12 @@ function renderEditor(email: string, update: Partial<Update> | null, images: Ima
     .status-msg { font-size: 0.85em; padding: 6px 12px; border-radius: 4px; display: none; }
     .status-msg.success { display: inline-block; background: #d4edda; color: #155724; }
     .status-msg.error { display: inline-block; background: #f8d7da; color: #721c24; }
+    .lint-warnings { margin: 12px 0; padding: 12px 16px; background: #fff3cd; border-left: 3px solid #ffc107; border-radius: 4px; font-size: 0.9em; color: #856404; display: none; }
+    .lint-warnings.visible { display: block; }
+    .lint-warnings .title { font-weight: 600; margin-bottom: 6px; }
+    .lint-warnings ul { margin: 0; padding-left: 20px; }
+    .lint-warnings li { margin: 2px 0; }
+    .lint-warnings .note { font-size: 0.85em; color: #6c757d; margin-top: 8px; font-style: italic; }
     .images-section { margin-top: 32px; border-top: 1px solid #dee2e6; padding-top: 24px; }
     .images-section h2 { font-size: 1em; margin: 0 0 16px; }
     .img-gallery { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 12px; }
@@ -153,6 +159,8 @@ function renderEditor(email: string, update: Partial<Update> | null, images: Ima
       ${!isNew ? `<a class="btn btn-secondary" href="/admin/preview/${escapeHtml(slug)}" target="_blank">Preview</a>` : ''}
       <span class="status-msg" id="status-msg"></span>
     </div>
+
+    <div class="lint-warnings" id="lint-warnings" role="status" aria-live="polite"></div>
 
     <div class="images-section">
       <h2>Images</h2>
@@ -369,12 +377,40 @@ function renderEditor(email: string, update: Partial<Update> | null, images: Ima
             }
           }
           showMessage('Saved!', 'success');
+          renderLintWarnings(data.warnings || []);
         } else {
           showMessage('Save failed: ' + (data.error || 'Unknown error'), 'error');
         }
       } catch (e) {
         showMessage('Save failed: network error', 'error');
       }
+    }
+
+    function renderLintWarnings(warnings) {
+      var box = document.getElementById('lint-warnings');
+      if (!box) return;
+      if (!warnings || warnings.length === 0) {
+        box.className = 'lint-warnings';
+        box.innerHTML = '';
+        return;
+      }
+      var items = warnings.map(function (w) {
+        return '<li>' + escapeTextForHtml(w.message) + '</li>';
+      }).join('');
+      box.innerHTML =
+        '<div class="title">Published with ' + warnings.length + ' warning' + (warnings.length === 1 ? '' : 's') + '</div>' +
+        '<ul>' + items + '</ul>' +
+        '<div class="note">These are advisory — your update was saved. Fix before next publish if you want.</div>';
+      box.className = 'lint-warnings visible';
+    }
+
+    function escapeTextForHtml(s) {
+      return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
     }
 
     function showMessage(msg, type) {

--- a/src/routes/gscStatus.ts
+++ b/src/routes/gscStatus.ts
@@ -1,0 +1,42 @@
+// ABOUT: GET /admin/api/gsc-status — returns the latest GSC snapshot from KV.
+// ABOUT: Auth-gated; used by the dashboard widget as its primary data source.
+
+import type { Env, GSCSnapshot } from '@/types';
+import { requireAuth } from '@/auth';
+
+export async function handleGscStatus(request: Request, env: Env): Promise<Response> {
+  const authResult = await requireAuth(request, env);
+  if (authResult instanceof Response) {
+    return authResult;
+  }
+
+  if (!env.GSC_KV) {
+    return json({ ok: false, error: 'GSC_KV binding not configured' }, 500);
+  }
+
+  const raw = await env.GSC_KV.get('status:latest');
+  if (!raw) {
+    // No snapshot yet (cron hasn't fired for the first time). Not an error —
+    // widget renders an empty state from this.
+    return json({ ok: true, snapshot: null });
+  }
+
+  let snapshot: GSCSnapshot;
+  try {
+    snapshot = JSON.parse(raw) as GSCSnapshot;
+  } catch {
+    return json({ ok: false, error: 'Corrupt snapshot in KV' }, 500);
+  }
+
+  return json({ ok: true, snapshot });
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'private, no-store',
+    },
+  });
+}

--- a/src/routes/refreshGsc.ts
+++ b/src/routes/refreshGsc.ts
@@ -1,0 +1,57 @@
+// ABOUT: POST /admin/api/refresh-gsc — manually triggers the GSC poll.
+// ABOUT: Uses skipDispatch so refreshing from the dashboard doesn't send emails
+// ABOUT: as a side effect (email is a cron-only behaviour). Rate-limited via
+// ABOUT: RATE_LIMIT_KV to prevent runaway clicks racing with the cron.
+
+import type { Env } from '@/types';
+import { requireAuth } from '@/auth';
+import { runDailyPoll } from '@/scheduled';
+import { sanitiseUpstreamError } from '@/gscHelpers';
+
+const RATE_LIMIT_SECONDS = 60;
+
+export async function handleRefreshGsc(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  if (origin !== new URL(request.url).origin) {
+    return json({ ok: false, error: 'Forbidden' }, 403);
+  }
+
+  const authResult = await requireAuth(request, env);
+  if (authResult instanceof Response) {
+    return authResult;
+  }
+
+  if (env.RATE_LIMIT_KV) {
+    const existing = await env.RATE_LIMIT_KV.get('gsc-refresh');
+    if (existing) {
+      return json({
+        ok: false,
+        error: `Refresh already ran within the last ${RATE_LIMIT_SECONDS}s — try again shortly.`,
+      }, 429);
+    }
+    await env.RATE_LIMIT_KV.put('gsc-refresh', new Date().toISOString(), {
+      expirationTtl: RATE_LIMIT_SECONDS,
+    });
+  }
+
+  try {
+    // skipDispatch: compute + persist, but do not send emails. Email is a
+    // cron-only side effect — a user clicking "Refresh" shouldn't be surprised
+    // by an alert email arriving in their inbox.
+    const snapshot = await runDailyPoll(env, { skipDispatch: true });
+    return json({ ok: true, snapshot });
+  } catch (err) {
+    console.error('refresh-gsc failed:', sanitiseUpstreamError(err));
+    return json({ ok: false, error: sanitiseUpstreamError(err) }, 500);
+  }
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'private, no-store',
+    },
+  });
+}

--- a/src/routes/saveUpdate.ts
+++ b/src/routes/saveUpdate.ts
@@ -6,6 +6,7 @@ import type { UpdateStatus } from '@/types';
 import { requireAuth } from '@/auth';
 import { fetchAllUpdates, fetchUpdateBySlug, saveUpdateFile } from '@/github';
 import { generateSlugFromTitle } from '@/utils';
+import { lintUpdate, type LintWarning } from '@/lint';
 
 const MAX_CONTENT_BYTES = 100 * 1024; // 100KB
 const VALID_STATUSES: UpdateStatus[] = ['draft', 'published', 'unpublished'];
@@ -117,7 +118,23 @@ export async function handleSaveUpdate(request: Request, env: Env): Promise<Resp
       return new Response(JSON.stringify({ error: result.error ?? 'Failed to save' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
     }
 
-    return new Response(JSON.stringify({ success: true, slug, isNew }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    // Compute non-blocking lint warnings. Only run when status is 'published' —
+    // drafts don't need lint noise. For duplicate-title detection we need the
+    // full existing-updates list; reuse the one already fetched for isNew, or
+    // fetch it once for edits being published.
+    let warnings: LintWarning[] = [];
+    if (status === 'published') {
+      const existingUpdates = isNew
+        ? (await fetchAllUpdates(env)).filter((u) => u.slug !== slug)
+        : await fetchAllUpdates(env);
+      warnings = lintUpdate({
+        update,
+        existingUpdates,
+        currentSlug: slug,
+      });
+    }
+
+    return new Response(JSON.stringify({ success: true, slug, isNew, warnings }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   } catch (error) {
     console.error('Error in handleSaveUpdate:', error);
     return new Response(JSON.stringify({ error: 'Internal server error' }), { status: 500, headers: { 'Content-Type': 'application/json' } });

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -31,6 +31,13 @@ const HISTORY_TTL_SECONDS = 35 * 24 * 60 * 60;
 export interface RunDailyPollOptions {
   siteUrl?: string;
   now?: Date;
+  /**
+   * If true, compute the snapshot (including alerts graduation) and persist
+   * it to KV, but do NOT send emails and do NOT write dedup keys. Used by the
+   * manual-refresh endpoint so a user clicking "Refresh" doesn't trigger
+   * surprise emails — email is a cron-only side effect.
+   */
+  skipDispatch?: boolean;
 }
 
 /**
@@ -85,12 +92,18 @@ export async function runDailyPoll(
     },
   };
 
-  const dispatched = await dispatchAlerts(env, kv, alerts, now);
-  snapshot.emailDelivery = mergeEmailDelivery(snapshot.emailDelivery, dispatched, now);
-  snapshot.alerts = snapshot.alerts.map((a, i) => ({
-    ...a,
-    emailSent: dispatched[i]?.sent ?? false,
-  }));
+  if (!opts.skipDispatch) {
+    const dispatched = await dispatchAlerts(env, kv, alerts, now);
+    snapshot.emailDelivery = mergeEmailDelivery(snapshot.emailDelivery, dispatched, now);
+    snapshot.alerts = snapshot.alerts.map((a, i) => ({
+      ...a,
+      emailSent: dispatched[i]?.sent ?? false,
+    }));
+  }
+  // When skipDispatch: alerts retain emailSent=false from resolveAlerts,
+  // emailDelivery is unchanged from previous, no dedup keys written. Next
+  // cron run will still see these alerts (via continuation logic) and deliver
+  // emails if conditions still hold.
 
   await Promise.all([
     kv.put('status:latest', JSON.stringify(snapshot)),
@@ -289,17 +302,29 @@ export function resolveAlerts(input: ResolveAlertsInput): ResolveAlertsOutput {
     }
   }
 
-  for (const cond of conditions) {
-    const wasAlerted = previouslyAlerted.has(cond.type);
-    const wasPending = previousPending.has(cond.type);
+  const previousAlertedByType = new Map<GSCAlertType, GSCAlert>(
+    (previousLatest?.alerts ?? []).map((a) => [a.type, a]),
+  );
 
-    if (wasAlerted || wasPending) {
+  for (const cond of conditions) {
+    const previousAlert = previousAlertedByType.get(cond.type);
+    const previousPendingEntry = previousPending.get(cond.type);
+
+    if (previousAlert || previousPendingEntry) {
       // Continuation (alerted → still alerting) or graduation (pending → alert).
+      // Preserve the ORIGINAL firstDetectedAt so the widget can render
+      // "seen for N days" honestly.
+      const firstDetectedAt =
+        previousAlert?.firstDetectedAt ??
+        previousPendingEntry?.firstDetectedAt ??
+        now.toISOString();
+
       alerts.push({
         type: cond.type,
         severity: cond.severity,
         subject: cond.subject,
         message: cond.message,
+        firstDetectedAt,
         detectedAt: now.toISOString(),
         emailSent: false,
         discriminator: cond.discriminator,

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,9 +128,13 @@ export interface GSCAlert {
   severity: 'high' | 'medium';
   subject: string; // short, magnitude-aware summary used for email subject lines
   message: string; // full message body explaining the condition
-  detectedAt: string;
+  firstDetectedAt: string; // ISO 8601 — when the condition was *first* observed
+                           // (preserved from the original pending entry through
+                           // graduation + continuation, so the UI can render
+                           // "seen for N days")
+  detectedAt: string;      // ISO 8601 — when this run observed the condition
   emailSent: boolean;
-  discriminator?: string; // optional per-alert dedup key (e.g. sitemap path)
+  discriminator?: string;  // optional per-alert dedup key (e.g. sitemap path)
 }
 
 export interface GSCPendingAlert {
@@ -167,6 +171,18 @@ export interface GSCPerformance {
   priorPeriodImpressions: number;
 }
 
+/**
+ * Email delivery state surfaced on the dashboard widget.
+ *
+ * `lastProvider` semantics:
+ *   `null`     — no delivery has been attempted yet (fresh state, no alerts fired)
+ *   `'cf'`     — most recent attempt succeeded via Cloudflare Email Sending
+ *   `'resend'` — most recent attempt succeeded via Resend (CF failed, fallback worked)
+ *   `'none'`   — most recent attempt failed at both providers
+ *
+ * Resolves GitHub issue #32: explicit documentation of the semantics
+ * the dashboard widget relies on.
+ */
 export interface GSCEmailDelivery {
   lastProvider: 'cf' | 'resend' | 'none' | null;
   lastSuccessAt: string | null;

--- a/tests/integration/gscStatus.test.ts
+++ b/tests/integration/gscStatus.test.ts
@@ -1,0 +1,104 @@
+// ABOUT: Integration tests for GET /admin/api/gsc-status.
+// ABOUT: Covers auth gating, empty KV, populated KV, corrupt snapshot.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import worker from '@/index';
+import { createMockEnv } from '../mocks/env';
+import { createMockContext } from '../mocks/context';
+import { generateJWT } from '@/auth';
+import type { GSCSnapshot } from '@/types';
+
+const SAMPLE_SNAPSHOT: GSCSnapshot = {
+  capturedAt: '2026-04-18T08:00:00Z',
+  siteUrl: 'sc-domain:hultberg.org',
+  sitemaps: [],
+  indexing: { indexedCount: 18 },
+  performance: {
+    period: '28d',
+    totalClicks: 100, totalImpressions: 3000, avgCtr: 0.033, avgPosition: 5,
+    topQueries: [], priorPeriodClicks: 80, priorPeriodImpressions: 2500,
+  },
+  alerts: [],
+  pendingAlerts: [],
+  emailDelivery: { lastProvider: null, lastSuccessAt: null, lastErrorAt: null },
+};
+
+describe('GET /admin/api/gsc-status', () => {
+  let mockEnv: any;
+  let mockCtx: ExecutionContext;
+
+  beforeEach(() => {
+    mockEnv = createMockEnv();
+    mockCtx = createMockContext();
+  });
+
+  it('redirects unauthenticated requests', async () => {
+    const request = new Request('http://localhost/admin/api/gsc-status', { method: 'GET' });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    // requireAuth returns a 302 response for unauth'd access
+    expect([302, 401]).toContain(response.status);
+  });
+
+  it('returns snapshot: null when KV is empty', async () => {
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    const request = new Request('http://localhost/admin/api/gsc-status', {
+      method: 'GET',
+      headers: { Cookie: `auth_token=${jwt}` },
+    });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    expect(response.status).toBe(200);
+    const body = await response.json() as { ok: boolean; snapshot: unknown };
+    expect(body.ok).toBe(true);
+    expect(body.snapshot).toBeNull();
+  });
+
+  it('returns the stored snapshot when present', async () => {
+    await mockEnv.GSC_KV.put('status:latest', JSON.stringify(SAMPLE_SNAPSHOT));
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    const request = new Request('http://localhost/admin/api/gsc-status', {
+      method: 'GET',
+      headers: { Cookie: `auth_token=${jwt}` },
+    });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    expect(response.status).toBe(200);
+    const body = await response.json() as { ok: boolean; snapshot: GSCSnapshot };
+    expect(body.ok).toBe(true);
+    expect(body.snapshot.siteUrl).toBe('sc-domain:hultberg.org');
+    expect(body.snapshot.indexing.indexedCount).toBe(18);
+  });
+
+  it('returns 500 when snapshot JSON is corrupt', async () => {
+    await mockEnv.GSC_KV.put('status:latest', '{not-valid-json');
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    const request = new Request('http://localhost/admin/api/gsc-status', {
+      method: 'GET',
+      headers: { Cookie: `auth_token=${jwt}` },
+    });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    expect(response.status).toBe(500);
+    const body = await response.json() as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('Corrupt');
+  });
+
+  it('returns 500 when GSC_KV binding is missing', async () => {
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    const envWithoutKV = { ...mockEnv, GSC_KV: undefined };
+    const request = new Request('http://localhost/admin/api/gsc-status', {
+      method: 'GET',
+      headers: { Cookie: `auth_token=${jwt}` },
+    });
+    const response = await worker.fetch(request, envWithoutKV, mockCtx);
+    expect(response.status).toBe(500);
+  });
+
+  it('sets a no-store cache-control header (admin data, per-user)', async () => {
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    const request = new Request('http://localhost/admin/api/gsc-status', {
+      method: 'GET',
+      headers: { Cookie: `auth_token=${jwt}` },
+    });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    expect(response.headers.get('Cache-Control')).toContain('no-store');
+  });
+});

--- a/tests/integration/refreshGsc.test.ts
+++ b/tests/integration/refreshGsc.test.ts
@@ -1,0 +1,156 @@
+// ABOUT: Integration tests for POST /admin/api/refresh-gsc.
+// ABOUT: Covers auth, origin check, rate limiting, skipDispatch semantics.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import worker from '@/index';
+import { createMockEnv } from '../mocks/env';
+import { createMockContext } from '../mocks/context';
+import { generateJWT } from '@/auth';
+
+const privateKeyPem = readFileSync(
+  join(__dirname, '..', 'fixtures', 'test-private-key.pem'),
+  'utf8',
+);
+
+const serviceAccountJson = JSON.stringify({
+  type: 'service_account',
+  client_email: 'test-sa@example.iam.gserviceaccount.com',
+  private_key: privateKeyPem,
+});
+
+function mockGSCFetch() {
+  global.fetch = vi.fn(async (input: RequestInfo | URL | string) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url === 'https://oauth2.googleapis.com/token') {
+      return new Response(JSON.stringify({ access_token: 't', expires_in: 3600 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.endsWith('/sitemaps')) {
+      return new Response(JSON.stringify({
+        sitemap: [{
+          path: 'https://hultberg.org/sitemap.xml',
+          errors: 0, warnings: 0,
+          contents: [{ type: 'web', submitted: '18', indexed: '5' }],
+        }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    if (url.endsWith('/searchAnalytics/query')) {
+      return new Response(JSON.stringify({ rows: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response('Not Found', { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+describe('POST /admin/api/refresh-gsc', () => {
+  let mockEnv: any;
+  let mockCtx: ExecutionContext;
+  let sendEmailMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sendEmailMock = vi.fn(async () => undefined);
+    mockEnv = createMockEnv({
+      GSC_SERVICE_ACCOUNT_JSON: serviceAccountJson,
+      ADMIN_EMAIL: 'magnus@example.com',
+      SEND_EMAIL: { send: sendEmailMock } as any,
+    });
+    mockCtx = createMockContext();
+    mockGSCFetch();
+  });
+
+  async function authedRequest(overrides: RequestInit = {}) {
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    return new Request('http://localhost/admin/api/refresh-gsc', {
+      method: 'POST',
+      headers: {
+        Cookie: `auth_token=${jwt}`,
+        Origin: 'http://localhost',
+        ...(overrides.headers as Record<string, string> ?? {}),
+      },
+      ...overrides,
+    });
+  }
+
+  it('redirects unauthenticated requests', async () => {
+    const request = new Request('http://localhost/admin/api/refresh-gsc', {
+      method: 'POST',
+      headers: { Origin: 'http://localhost' },
+    });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    expect([302, 401]).toContain(response.status);
+  });
+
+  it('rejects cross-origin requests', async () => {
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    const request = new Request('http://localhost/admin/api/refresh-gsc', {
+      method: 'POST',
+      headers: {
+        Cookie: `auth_token=${jwt}`,
+        Origin: 'http://evil.example.com',
+      },
+    });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    expect(response.status).toBe(403);
+  });
+
+  it('runs the poll and returns the new snapshot', async () => {
+    const response = await worker.fetch(await authedRequest(), mockEnv, mockCtx);
+    expect(response.status).toBe(200);
+    const body = await response.json() as { ok: boolean; snapshot: any };
+    expect(body.ok).toBe(true);
+    expect(body.snapshot.indexing.indexedCount).toBe(5);
+  });
+
+  it('does NOT send email even when alerts graduate (skipDispatch semantics)', async () => {
+    // Seed pending-state so today's observation would normally graduate + email.
+    const weekAgo = {
+      capturedAt: '2026-04-11T08:00:00Z',
+      siteUrl: 'sc-domain:hultberg.org',
+      sitemaps: [],
+      indexing: { indexedCount: 20 },
+      performance: {
+        period: '28d', totalClicks: 0, totalImpressions: 0, avgCtr: 0, avgPosition: 0,
+        topQueries: [], priorPeriodClicks: 0, priorPeriodImpressions: 0,
+      },
+      alerts: [], pendingAlerts: [],
+      emailDelivery: { lastProvider: null, lastSuccessAt: null, lastErrorAt: null },
+    };
+    const previousLatest = {
+      ...weekAgo,
+      capturedAt: '2026-04-17T08:00:00Z',
+      indexing: { indexedCount: 5 },
+      pendingAlerts: [{ type: 'indexed-drop', firstDetectedAt: '2026-04-17T08:00:00Z' }],
+    };
+    await mockEnv.GSC_KV.put('status:history:2026-04-11', JSON.stringify(weekAgo));
+    await mockEnv.GSC_KV.put('status:latest', JSON.stringify(previousLatest));
+
+    const response = await worker.fetch(await authedRequest(), mockEnv, mockCtx);
+    expect(response.status).toBe(200);
+    const body = await response.json() as { ok: boolean; snapshot: any };
+
+    // Alert IS graduated into the snapshot (refresh computes state)...
+    expect(body.snapshot.alerts).toHaveLength(1);
+    expect(body.snapshot.alerts[0].type).toBe('indexed-drop');
+    expect(body.snapshot.alerts[0].emailSent).toBe(false);
+    // ...but email was NOT sent (refresh skips dispatch).
+    expect(sendEmailMock).not.toHaveBeenCalled();
+    // ...and no dedup key was written, so the next cron will still deliver.
+    expect(await mockEnv.GSC_KV.get('alert:dedup:indexed-drop:')).toBeNull();
+  });
+
+  it('rate-limits a second refresh within the window', async () => {
+    const first = await worker.fetch(await authedRequest(), mockEnv, mockCtx);
+    expect(first.status).toBe(200);
+
+    const second = await worker.fetch(await authedRequest(), mockEnv, mockCtx);
+    expect(second.status).toBe(429);
+    const body = await second.json() as { ok: boolean; error: string };
+    expect(body.error).toContain('60s');
+  });
+});

--- a/tests/integration/refreshGsc.test.ts
+++ b/tests/integration/refreshGsc.test.ts
@@ -109,8 +109,16 @@ describe('POST /admin/api/refresh-gsc', () => {
 
   it('does NOT send email even when alerts graduate (skipDispatch semantics)', async () => {
     // Seed pending-state so today's observation would normally graduate + email.
+    // Compute the 7-day-ago history key from real "now" — the refresh endpoint
+    // doesn't accept a `now` override, so we have to align with the wall clock.
+    const realNow = new Date();
+    const sevenDaysAgo = new Date(realNow);
+    sevenDaysAgo.setUTCDate(sevenDaysAgo.getUTCDate() - 7);
+    const yyyymmdd = (d: Date) =>
+      `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+
     const weekAgo = {
-      capturedAt: '2026-04-11T08:00:00Z',
+      capturedAt: sevenDaysAgo.toISOString(),
       siteUrl: 'sc-domain:hultberg.org',
       sitemaps: [],
       indexing: { indexedCount: 20 },
@@ -123,11 +131,11 @@ describe('POST /admin/api/refresh-gsc', () => {
     };
     const previousLatest = {
       ...weekAgo,
-      capturedAt: '2026-04-17T08:00:00Z',
+      capturedAt: realNow.toISOString(),
       indexing: { indexedCount: 5 },
-      pendingAlerts: [{ type: 'indexed-drop', firstDetectedAt: '2026-04-17T08:00:00Z' }],
+      pendingAlerts: [{ type: 'indexed-drop', firstDetectedAt: realNow.toISOString() }],
     };
-    await mockEnv.GSC_KV.put('status:history:2026-04-11', JSON.stringify(weekAgo));
+    await mockEnv.GSC_KV.put(`status:history:${yyyymmdd(sevenDaysAgo)}`, JSON.stringify(weekAgo));
     await mockEnv.GSC_KV.put('status:latest', JSON.stringify(previousLatest));
 
     const response = await worker.fetch(await authedRequest(), mockEnv, mockCtx);

--- a/tests/integration/scheduled.test.ts
+++ b/tests/integration/scheduled.test.ts
@@ -242,6 +242,44 @@ describe('runDailyPoll', () => {
     expect(snapshot.emailDelivery).toEqual(previousLatest.emailDelivery);
   });
 
+  it('skipDispatch: graduates alerts but does NOT send email or write dedup keys', async () => {
+    // Set up for graduation: previous pending, conditions still trigger today.
+    const weekAgo: GSCSnapshot = {
+      capturedAt: '2026-04-11T08:00:00Z',
+      siteUrl: SITE_URL, sitemaps: [],
+      indexing: { indexedCount: 20 },
+      performance: {
+        period: '28d', totalClicks: 0, totalImpressions: 0, avgCtr: 0, avgPosition: 0,
+        topQueries: [], priorPeriodClicks: 0, priorPeriodImpressions: 0,
+      },
+      alerts: [], pendingAlerts: [],
+      emailDelivery: { lastProvider: null, lastSuccessAt: null, lastErrorAt: null },
+    };
+    const previousLatest: GSCSnapshot = {
+      ...weekAgo,
+      capturedAt: '2026-04-17T08:00:00Z',
+      indexing: { indexedCount: 10 },
+      pendingAlerts: [{ type: 'indexed-drop', firstDetectedAt: '2026-04-17T08:00:00Z' }],
+    };
+    await env.GSC_KV!.put('status:history:2026-04-11', JSON.stringify(weekAgo));
+    await env.GSC_KV!.put('status:latest', JSON.stringify(previousLatest));
+
+    mockGSCApi({ sitemaps: goodSitemapsResponse({ indexed: '10' }) });
+
+    const snapshot = await runDailyPoll(env, { now: NOW, siteUrl: SITE_URL, skipDispatch: true });
+
+    // Alert is graduated and present in snapshot (state machine still runs).
+    expect(snapshot.alerts).toHaveLength(1);
+    expect(snapshot.alerts[0].type).toBe('indexed-drop');
+    // But no email was sent and emailSent stays false.
+    expect(snapshot.alerts[0].emailSent).toBe(false);
+    expect(sendEmailMock).not.toHaveBeenCalled();
+    // Email delivery state is untouched — refresh doesn't advance it.
+    expect(snapshot.emailDelivery).toEqual(previousLatest.emailDelivery);
+    // Crucially: no dedup key written, so the next cron run will attempt delivery.
+    expect(await env.GSC_KV!.get('alert:dedup:indexed-drop:')).toBeNull();
+  });
+
   it('handles an empty sitemap list gracefully', async () => {
     mockGSCApi({ sitemaps: { sitemap: [] } });
 

--- a/tests/unit/gscWidgetDom.test.ts
+++ b/tests/unit/gscWidgetDom.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+/// <reference lib="dom" />
+// ABOUT: JSDOM tests for the DOM-touching helpers in public/admin/gsc-widget.js
+// ABOUT: (showRefreshError, clearRefreshError, restoreRefreshButton, escapeHtml).
+// ABOUT: Loads the actual widget source via Function() with the test hook enabled
+// ABOUT: so we exercise the production code, not a copy.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const widgetSource = readFileSync(
+  join(__dirname, '..', '..', 'public', 'admin', 'gsc-widget.js'),
+  'utf8',
+);
+
+interface WidgetTestApi {
+  escapeHtml: (s: string) => string;
+  showRefreshError: (message: string) => void;
+  clearRefreshError: () => void;
+  restoreRefreshButton: () => void;
+  computeViewModel: (snapshot: unknown, now: Date) => unknown;
+}
+
+declare global {
+  interface Window {
+    __gscWidgetTest?: { api?: WidgetTestApi };
+  }
+}
+
+function loadWidget(): WidgetTestApi {
+  // Set the test hook BEFORE evaluating the script so the IIFE's branch
+  // attaches the api and skips the auto-load.
+  window.__gscWidgetTest = {};
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  new Function(widgetSource).call(window);
+  if (!window.__gscWidgetTest.api) {
+    throw new Error('gsc-widget.js did not attach the test API — check the test hook gate.');
+  }
+  return window.__gscWidgetTest.api;
+}
+
+describe('gsc-widget DOM helpers', () => {
+  let api: WidgetTestApi;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    api = loadWidget();
+  });
+
+  describe('escapeHtml', () => {
+    it('escapes the five HTML metacharacters', () => {
+      expect(api.escapeHtml('<script>alert("x&y")</script>')).toBe(
+        '&lt;script&gt;alert(&quot;x&amp;y&quot;)&lt;/script&gt;',
+      );
+    });
+
+    it('escapes single quotes', () => {
+      expect(api.escapeHtml("it's")).toBe('it&#039;s');
+    });
+
+    it('passes through plain text unchanged', () => {
+      expect(api.escapeHtml('plain text 123')).toBe('plain text 123');
+    });
+
+    it('coerces non-string input to string before escaping', () => {
+      expect(api.escapeHtml(42 as unknown as string)).toBe('42');
+    });
+  });
+
+  describe('showRefreshError', () => {
+    function setupWidget(): HTMLElement {
+      document.body.innerHTML = `
+        <div id="gsc-widget-root">
+          <section class="widget">
+            <div class="widget-header">
+              <h2>Search visibility</h2>
+              <button id="gsc-refresh-btn">↻ Refresh</button>
+            </div>
+            <div class="alerts"><div class="alert">existing alert content</div></div>
+            <div class="tiles"><div class="tile">existing tile</div></div>
+          </section>
+        </div>
+      `;
+      return document.querySelector('.widget')!;
+    }
+
+    it('inserts a banner above the widget header', () => {
+      const widget = setupWidget();
+      api.showRefreshError('Rate limit hit — try again in 60s');
+
+      const banner = document.getElementById('gsc-refresh-error');
+      expect(banner).not.toBeNull();
+      expect(banner!.textContent).toContain('Rate limit hit');
+      expect(widget.firstElementChild).toBe(banner);
+    });
+
+    it('preserves all existing widget content (alerts, tiles, header)', () => {
+      setupWidget();
+      api.showRefreshError('whatever');
+
+      expect(document.querySelector('.alerts')!.textContent).toContain('existing alert content');
+      expect(document.querySelector('.tiles')!.textContent).toContain('existing tile');
+      expect(document.getElementById('gsc-refresh-btn')).not.toBeNull();
+    });
+
+    it('escapes HTML in the error message (XSS defence)', () => {
+      setupWidget();
+      api.showRefreshError('<img src=x onerror=alert(1)>');
+
+      const banner = document.getElementById('gsc-refresh-error');
+      expect(banner!.innerHTML).not.toContain('<img');
+      expect(banner!.innerHTML).toContain('&lt;img');
+      // Verify no actual img element was injected.
+      expect(banner!.querySelector('img')).toBeNull();
+    });
+
+    it('replaces an existing banner rather than stacking duplicates', () => {
+      setupWidget();
+      api.showRefreshError('first error');
+      api.showRefreshError('second error');
+
+      const banners = document.querySelectorAll('#gsc-refresh-error');
+      expect(banners.length).toBe(1);
+      expect(banners[0].textContent).toContain('second error');
+      expect(banners[0].textContent).not.toContain('first error');
+    });
+
+    it('marks the banner with role="alert" for screen readers', () => {
+      setupWidget();
+      api.showRefreshError('x');
+
+      const banner = document.getElementById('gsc-refresh-error');
+      expect(banner!.getAttribute('role')).toBe('alert');
+    });
+
+    it('attaches a working dismiss handler to the × button', () => {
+      setupWidget();
+      api.showRefreshError('dismissible');
+
+      const dismissBtn = document.querySelector('#gsc-refresh-error .dismiss') as HTMLButtonElement;
+      expect(dismissBtn).not.toBeNull();
+      dismissBtn.click();
+
+      expect(document.getElementById('gsc-refresh-error')).toBeNull();
+    });
+
+    it('is a no-op when there is no .widget element on the page', () => {
+      document.body.innerHTML = '<div>no widget here</div>';
+      expect(() => api.showRefreshError('x')).not.toThrow();
+      expect(document.getElementById('gsc-refresh-error')).toBeNull();
+    });
+  });
+
+  describe('clearRefreshError', () => {
+    it('removes the banner if present', () => {
+      document.body.innerHTML = `
+        <div id="gsc-widget-root">
+          <section class="widget"><div class="widget-header"></div></section>
+        </div>
+      `;
+      api.showRefreshError('temporary');
+      expect(document.getElementById('gsc-refresh-error')).not.toBeNull();
+
+      api.clearRefreshError();
+      expect(document.getElementById('gsc-refresh-error')).toBeNull();
+    });
+
+    it('is a safe no-op when no banner is present', () => {
+      document.body.innerHTML = '<div>nothing to clear</div>';
+      expect(() => api.clearRefreshError()).not.toThrow();
+    });
+  });
+
+  describe('restoreRefreshButton', () => {
+    it('re-enables the button and resets the text', () => {
+      document.body.innerHTML = `
+        <button id="gsc-refresh-btn" disabled>Refreshing…</button>
+      `;
+      api.restoreRefreshButton();
+
+      const btn = document.getElementById('gsc-refresh-btn') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+      expect(btn.textContent).toBe('↻ Refresh');
+    });
+
+    it('is a safe no-op when the button is not on the page', () => {
+      document.body.innerHTML = '<div>no refresh button</div>';
+      expect(() => api.restoreRefreshButton()).not.toThrow();
+    });
+  });
+});

--- a/tests/unit/gscWidgetViewModel.test.ts
+++ b/tests/unit/gscWidgetViewModel.test.ts
@@ -1,0 +1,215 @@
+// ABOUT: Unit tests for the GSC dashboard widget view-model.
+
+import { describe, it, expect } from 'vitest';
+import { renderViewModel } from '@/gscWidgetViewModel';
+import type { GSCSnapshot } from '@/types';
+
+const NOW = new Date('2026-04-18T12:00:00Z');
+
+function makeSnapshot(overrides: Partial<GSCSnapshot> = {}): GSCSnapshot {
+  return {
+    capturedAt: '2026-04-18T08:00:00Z', // 4h ago
+    siteUrl: 'sc-domain:hultberg.org',
+    sitemaps: [{
+      path: 'https://hultberg.org/sitemap.xml',
+      lastSubmitted: null, lastDownloaded: null,
+      errors: 0, warnings: 0, submitted: 20, indexed: 18,
+    }],
+    indexing: { indexedCount: 18 },
+    performance: {
+      period: '28d',
+      totalClicks: 120, totalImpressions: 4000, avgCtr: 0.03, avgPosition: 5,
+      topQueries: [], priorPeriodClicks: 100, priorPeriodImpressions: 3500,
+    },
+    alerts: [],
+    pendingAlerts: [],
+    emailDelivery: { lastProvider: null, lastSuccessAt: null, lastErrorAt: null },
+    ...overrides,
+  };
+}
+
+describe('renderViewModel — empty state', () => {
+  it('returns empty state when snapshot is null', () => {
+    const vm = renderViewModel(null, NOW);
+    expect(vm.state).toBe('empty');
+    expect(vm.freshnessLabel).toContain('No data yet');
+    expect(vm.alerts).toEqual([]);
+    expect(vm.kpis).toEqual([]);
+    expect(vm.topQueries).toEqual([]);
+    expect(vm.emailDelivery.kind).toBe('idle');
+  });
+});
+
+describe('renderViewModel — freshness', () => {
+  it('marks 4h-old snapshot as fresh', () => {
+    const vm = renderViewModel(makeSnapshot({ capturedAt: '2026-04-18T08:00:00Z' }), NOW);
+    expect(vm.state).toBe('fresh');
+    expect(vm.freshnessLabel).toBe('Refreshed 4 hours ago');
+  });
+
+  it('marks 36h+ snapshot as stale', () => {
+    const vm = renderViewModel(
+      makeSnapshot({ capturedAt: '2026-04-17T00:00:00Z' }),
+      NOW,
+    );
+    expect(vm.state).toBe('stale');
+  });
+
+  it('uses day-granularity for older snapshots', () => {
+    const vm = renderViewModel(
+      makeSnapshot({ capturedAt: '2026-04-15T12:00:00Z' }), // 3 days ago
+      NOW,
+    );
+    expect(vm.freshnessLabel).toBe('Refreshed 3 days ago');
+  });
+});
+
+describe('renderViewModel — KPIs', () => {
+  it('emits four KPI tiles in the expected order', () => {
+    const vm = renderViewModel(makeSnapshot(), NOW);
+    expect(vm.kpis.map((k) => k.label)).toEqual([
+      'Indexed pages',
+      'Sitemap',
+      'Clicks (28d)',
+      'Impressions (28d)',
+    ]);
+  });
+
+  it('formats sitemap as "indexed / submitted"', () => {
+    const vm = renderViewModel(makeSnapshot(), NOW);
+    const sitemap = vm.kpis.find((k) => k.label === 'Sitemap')!;
+    expect(sitemap.value).toBe('18 / 20');
+    expect(sitemap.sub).toBe('indexed / submitted');
+  });
+
+  it('shows an up-delta class when clicks grew', () => {
+    const vm = renderViewModel(
+      makeSnapshot({
+        performance: {
+          period: '28d',
+          totalClicks: 120, totalImpressions: 4000, avgCtr: 0.03, avgPosition: 5,
+          topQueries: [], priorPeriodClicks: 100, priorPeriodImpressions: 3500,
+        },
+      }),
+      NOW,
+    );
+    const clicks = vm.kpis.find((k) => k.label === 'Clicks (28d)')!;
+    expect(clicks.value).toBe('120');
+    expect(clicks.deltaClass).toBe('up');
+    expect(clicks.sub).toContain('+20%');
+  });
+
+  it('shows a down-delta class when impressions fell', () => {
+    const vm = renderViewModel(
+      makeSnapshot({
+        performance: {
+          period: '28d',
+          totalClicks: 80, totalImpressions: 2000, avgCtr: 0.04, avgPosition: 5,
+          topQueries: [], priorPeriodClicks: 100, priorPeriodImpressions: 4000,
+        },
+      }),
+      NOW,
+    );
+    const impressions = vm.kpis.find((k) => k.label === 'Impressions (28d)')!;
+    expect(impressions.deltaClass).toBe('down');
+    expect(impressions.sub).toContain('-50%');
+  });
+});
+
+describe('renderViewModel — top queries', () => {
+  it('pre-formats ctr and position for rendering', () => {
+    const vm = renderViewModel(
+      makeSnapshot({
+        performance: {
+          period: '28d',
+          totalClicks: 120, totalImpressions: 4000, avgCtr: 0.03, avgPosition: 5,
+          topQueries: [
+            { query: 'magnus hultberg', clicks: 100, impressions: 2000, ctr: 0.05, position: 2.17 },
+          ],
+          priorPeriodClicks: 100, priorPeriodImpressions: 3500,
+        },
+      }),
+      NOW,
+    );
+    expect(vm.topQueries).toHaveLength(1);
+    expect(vm.topQueries[0].query).toBe('magnus hultberg');
+    expect(vm.topQueries[0].ctrPct).toBe('5.0%');
+    expect(vm.topQueries[0].position).toBe('2.2');
+  });
+});
+
+describe('renderViewModel — alerts', () => {
+  it('calculates days-seen from firstDetectedAt', () => {
+    const vm = renderViewModel(
+      makeSnapshot({
+        alerts: [{
+          type: 'indexed-drop',
+          severity: 'high',
+          subject: 'Indexed pages dropped 50%',
+          message: 'x',
+          firstDetectedAt: '2026-04-16T08:00:00Z', // 2 days ago
+          detectedAt: '2026-04-18T08:00:00Z',
+          emailSent: true,
+        }],
+      }),
+      NOW,
+    );
+    expect(vm.alerts).toHaveLength(1);
+    expect(vm.alerts[0].daysSeen).toBe(3); // inclusive count
+    expect(vm.alerts[0].emailSent).toBe(true);
+  });
+});
+
+describe('renderViewModel — email delivery', () => {
+  it('reports "Never attempted" for a pristine state', () => {
+    const vm = renderViewModel(makeSnapshot(), NOW);
+    expect(vm.emailDelivery.kind).toBe('idle');
+    expect(vm.emailDelivery.label).toBe('Never attempted');
+  });
+
+  it('reports CF provider as ok', () => {
+    const vm = renderViewModel(
+      makeSnapshot({
+        emailDelivery: {
+          lastProvider: 'cf',
+          lastSuccessAt: '2026-04-18T10:00:00Z',
+          lastErrorAt: null,
+        },
+      }),
+      NOW,
+    );
+    expect(vm.emailDelivery.kind).toBe('ok');
+    expect(vm.emailDelivery.label).toContain('CF');
+    expect(vm.emailDelivery.label).toContain('2h ago');
+  });
+
+  it('reports Resend fallback as warn', () => {
+    const vm = renderViewModel(
+      makeSnapshot({
+        emailDelivery: {
+          lastProvider: 'resend',
+          lastSuccessAt: '2026-04-18T11:00:00Z',
+          lastErrorAt: null,
+        },
+      }),
+      NOW,
+    );
+    expect(vm.emailDelivery.kind).toBe('warn');
+    expect(vm.emailDelivery.label).toContain('Resend');
+  });
+
+  it("reports 'none' provider as error", () => {
+    const vm = renderViewModel(
+      makeSnapshot({
+        emailDelivery: {
+          lastProvider: 'none',
+          lastSuccessAt: null,
+          lastErrorAt: '2026-04-18T11:00:00Z',
+        },
+      }),
+      NOW,
+    );
+    expect(vm.emailDelivery.kind).toBe('error');
+    expect(vm.emailDelivery.label).toContain('Both providers failed');
+  });
+});

--- a/tests/unit/gscWidgetViewModel.test.ts
+++ b/tests/unit/gscWidgetViewModel.test.ts
@@ -138,6 +138,47 @@ describe('renderViewModel — top queries', () => {
   });
 });
 
+describe('renderViewModel — alerts back-compat', () => {
+  it('falls back to detectedAt when firstDetectedAt is missing (PR #29 legacy snapshot)', () => {
+    // Construct an alert object as PR #29 wrote it — without firstDetectedAt.
+    const legacyAlert = {
+      type: 'sitemap-error' as const,
+      severity: 'high' as const,
+      subject: 'x',
+      message: 'x',
+      detectedAt: '2026-04-16T08:00:00Z',
+      emailSent: true,
+    } as unknown as GSCSnapshot['alerts'][number];
+
+    const vm = renderViewModel(
+      makeSnapshot({ alerts: [legacyAlert] }),
+      NOW,
+    );
+    expect(vm.alerts).toHaveLength(1);
+    // Must NOT be NaN.
+    expect(Number.isNaN(vm.alerts[0].daysSeen)).toBe(false);
+    expect(vm.alerts[0].daysSeen).toBe(3);
+    expect(vm.alerts[0].firstDetectedAt).toBe('2026-04-16T08:00:00Z');
+  });
+
+  it('falls back to snapshot.capturedAt when both firstDetectedAt and detectedAt are missing', () => {
+    const verylegacy = {
+      type: 'sitemap-error' as const,
+      severity: 'high' as const,
+      subject: 'x',
+      message: 'x',
+      emailSent: true,
+    } as unknown as GSCSnapshot['alerts'][number];
+
+    const vm = renderViewModel(
+      makeSnapshot({ alerts: [verylegacy], capturedAt: '2026-04-17T08:00:00Z' }),
+      NOW,
+    );
+    expect(Number.isNaN(vm.alerts[0].daysSeen)).toBe(false);
+    expect(vm.alerts[0].firstDetectedAt).toBe('2026-04-17T08:00:00Z');
+  });
+});
+
 describe('renderViewModel — alerts', () => {
   it('calculates days-seen from firstDetectedAt', () => {
     const vm = renderViewModel(

--- a/tests/unit/lint.test.ts
+++ b/tests/unit/lint.test.ts
@@ -1,0 +1,153 @@
+// ABOUT: Unit tests for the pre-publish lint rules.
+
+import { describe, it, expect } from 'vitest';
+import { lintUpdate } from '@/lint';
+import type { Update } from '@/types';
+
+type Existing = Pick<Update, 'title' | 'status' | 'slug'>;
+
+function makeUpdate(overrides: Partial<Pick<Update, 'title' | 'excerpt' | 'content' | 'images'>> = {}) {
+  return {
+    title: 'A fine update',
+    excerpt: 'An appropriately long excerpt for social previews.',
+    content: 'x'.repeat(400),
+    images: [] as string[],
+    ...overrides,
+  };
+}
+
+describe('lintUpdate — clean input', () => {
+  it('returns no warnings when everything looks good', () => {
+    const warnings = lintUpdate({
+      update: makeUpdate({ images: ['/images/updates/foo.jpg'] }),
+      existingUpdates: [],
+    });
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe('lintUpdate — missing-excerpt', () => {
+  it('warns when excerpt is empty', () => {
+    const warnings = lintUpdate({
+      update: makeUpdate({ excerpt: '', images: ['/img/a.jpg'] }),
+      existingUpdates: [],
+    });
+    expect(warnings.map((w) => w.rule)).toContain('missing-excerpt');
+  });
+
+  it('treats whitespace-only excerpt as empty', () => {
+    const warnings = lintUpdate({
+      update: makeUpdate({ excerpt: '   \n\t ', images: ['/img/a.jpg'] }),
+      existingUpdates: [],
+    });
+    expect(warnings.map((w) => w.rule)).toContain('missing-excerpt');
+  });
+});
+
+describe('lintUpdate — thin-content', () => {
+  it('warns when content is shorter than 300 chars', () => {
+    const warnings = lintUpdate({
+      update: makeUpdate({ content: 'short' }),
+      existingUpdates: [],
+    });
+    expect(warnings.map((w) => w.rule)).toContain('thin-content');
+    expect(warnings.find((w) => w.rule === 'thin-content')?.message).toContain('5 characters');
+  });
+
+  it('does not warn at exactly 300 chars', () => {
+    const warnings = lintUpdate({
+      update: makeUpdate({ content: 'x'.repeat(300) }),
+      existingUpdates: [],
+    });
+    expect(warnings.map((w) => w.rule)).not.toContain('thin-content');
+  });
+});
+
+describe('lintUpdate — duplicate-title', () => {
+  it('warns when a published update has the same title', () => {
+    const existing: Existing[] = [
+      { title: 'A fine update', status: 'published', slug: 'a-fine-update' },
+    ];
+    const warnings = lintUpdate({
+      update: makeUpdate({ title: 'A fine update' }),
+      existingUpdates: existing,
+    });
+    const dupe = warnings.find((w) => w.rule === 'duplicate-title');
+    expect(dupe).toBeTruthy();
+    expect(dupe?.message).toContain('a-fine-update');
+  });
+
+  it('is case-insensitive', () => {
+    const existing: Existing[] = [
+      { title: 'A Fine Update', status: 'published', slug: 'a-fine-update' },
+    ];
+    const warnings = lintUpdate({
+      update: makeUpdate({ title: 'a fine update' }),
+      existingUpdates: existing,
+    });
+    expect(warnings.map((w) => w.rule)).toContain('duplicate-title');
+  });
+
+  it('ignores updates with non-published status', () => {
+    const existing: Existing[] = [
+      { title: 'A fine update', status: 'draft', slug: 'a-fine-update' },
+      { title: 'A fine update', status: 'unpublished', slug: 'b-fine-update' },
+    ];
+    const warnings = lintUpdate({
+      update: makeUpdate({ title: 'A fine update' }),
+      existingUpdates: existing,
+    });
+    expect(warnings.map((w) => w.rule)).not.toContain('duplicate-title');
+  });
+
+  it('excludes the current update itself when editing', () => {
+    const existing: Existing[] = [
+      { title: 'A fine update', status: 'published', slug: 'a-fine-update' },
+    ];
+    const warnings = lintUpdate({
+      update: makeUpdate({ title: 'A fine update' }),
+      existingUpdates: existing,
+      currentSlug: 'a-fine-update',
+    });
+    expect(warnings.map((w) => w.rule)).not.toContain('duplicate-title');
+  });
+});
+
+describe('lintUpdate — poor-social-preview', () => {
+  it('warns when no excerpt AND no images', () => {
+    const warnings = lintUpdate({
+      update: makeUpdate({ excerpt: '', images: [] }),
+      existingUpdates: [],
+    });
+    expect(warnings.map((w) => w.rule)).toContain('poor-social-preview');
+  });
+
+  it('does not warn when an image is present even with empty excerpt', () => {
+    const warnings = lintUpdate({
+      update: makeUpdate({ excerpt: '', images: ['/img/a.jpg'] }),
+      existingUpdates: [],
+    });
+    expect(warnings.map((w) => w.rule)).not.toContain('poor-social-preview');
+  });
+
+  it('does not warn when excerpt is present even with no images', () => {
+    const warnings = lintUpdate({
+      update: makeUpdate({ excerpt: 'a good excerpt', images: [] }),
+      existingUpdates: [],
+    });
+    expect(warnings.map((w) => w.rule)).not.toContain('poor-social-preview');
+  });
+});
+
+describe('lintUpdate — multiple rules', () => {
+  it('returns all applicable warnings together', () => {
+    const warnings = lintUpdate({
+      update: makeUpdate({ excerpt: '', content: 'tiny', images: [] }),
+      existingUpdates: [],
+    });
+    const rules = warnings.map((w) => w.rule);
+    expect(rules).toContain('missing-excerpt');
+    expect(rules).toContain('thin-content');
+    expect(rules).toContain('poor-social-preview');
+  });
+});

--- a/tests/unit/scheduled-resolveAlerts.test.ts
+++ b/tests/unit/scheduled-resolveAlerts.test.ts
@@ -182,6 +182,48 @@ describe('resolveAlerts — new-crawl-warning (warnings)', () => {
   });
 });
 
+describe('resolveAlerts — firstDetectedAt preservation', () => {
+  it('preserves firstDetectedAt from a pending entry on graduation', () => {
+    const pendingTimestamp = '2026-04-17T08:00:00Z';
+    const { alerts } = resolveAlerts({
+      now: NOW,
+      current: { indexedCount: 10, sitemaps: [makeSitemap({ indexed: 10 })], performance: makePerformance() },
+      previousLatest: makeSnapshot({
+        pendingAlerts: [{ type: 'indexed-drop', firstDetectedAt: pendingTimestamp }],
+      }),
+      weekAgo: makeSnapshot({ indexing: { indexedCount: 20 } }),
+    });
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].firstDetectedAt).toBe(pendingTimestamp);
+    expect(alerts[0].detectedAt).toBe(NOW.toISOString());
+  });
+
+  it('preserves firstDetectedAt from a previously-alerted entry on continuation', () => {
+    const originalFirstDetected = '2026-04-15T08:00:00Z';
+    const { alerts } = resolveAlerts({
+      now: NOW,
+      current: { indexedCount: 10, sitemaps: [makeSitemap({ indexed: 10 })], performance: makePerformance() },
+      previousLatest: makeSnapshot({
+        alerts: [{
+          type: 'indexed-drop',
+          severity: 'high',
+          subject: 'Indexed pages dropped 50% (20→10)',
+          message: 'x',
+          firstDetectedAt: originalFirstDetected,
+          detectedAt: '2026-04-17T08:00:00Z',
+          emailSent: true,
+        }],
+      }),
+      weekAgo: makeSnapshot({ indexing: { indexedCount: 20 } }),
+    });
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].firstDetectedAt).toBe(originalFirstDetected);
+    expect(alerts[0].detectedAt).toBe(NOW.toISOString());
+  });
+});
+
 describe('resolveAlerts — continuation (no pending re-pending oscillation)', () => {
   it('keeps a previously-alerted, still-triggering condition in alerts (not recycled to pending)', () => {
     const previousLatest = makeSnapshot({
@@ -190,6 +232,7 @@ describe('resolveAlerts — continuation (no pending re-pending oscillation)', (
         severity: 'high',
         subject: 'Indexed pages dropped 50% (20→10)',
         message: 'x',
+        firstDetectedAt: '2026-04-15T08:00:00Z',
         detectedAt: '2026-04-17T08:00:00Z',
         emailSent: true,
       }],
@@ -215,6 +258,7 @@ describe('resolveAlerts — continuation (no pending re-pending oscillation)', (
         severity: 'high',
         subject: 'x',
         message: 'x',
+        firstDetectedAt: '2026-04-15T08:00:00Z',
         detectedAt: '2026-04-17T08:00:00Z',
         emailSent: true,
       }],

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,6 @@
 name = "hultberg-org"
 main = "src/index.ts"
 compatibility_date = "2024-06-28"
-format = "modules"
 
 [observability.logs]
 enabled = true


### PR DESCRIPTION
## Summary

Second and final PR for the GSC Insights feature (Layer 1). PR #29 landed the cron + email plumbing; this PR adds everything user-facing on top.

Completes the spec: [`SPECIFICATIONS/ARCHIVE/gsc-insights-and-alerts.md`](../blob/main/SPECIFICATIONS/ARCHIVE/gsc-insights-and-alerts.md). How-it-works doc: [`REFERENCE/gsc-insights.md`](../blob/main/REFERENCE/gsc-insights.md).

## What's included

### Endpoints (auth-gated)

- **`GET /admin/api/gsc-status`** — returns latest snapshot from KV (or \`{snapshot: null}\` when cron hasn't fired yet).
- **`POST /admin/api/refresh-gsc`** — triggers \`runDailyPoll\` on demand. Rate-limited to 1/60s via \`RATE_LIMIT_KV\`. Uses the new **\`skipDispatch\`** option so refresh doesn't send emails — email is a cron-only side effect.

### Dashboard widget

- **`public/admin/gsc-widget.js`** — client-side DOM renderer.
- **`src/gscWidgetViewModel.ts`** — pure \`renderViewModel(snapshot, now)\` with full unit coverage. The client mirrors it for live display with the browser's clock.
- Wired into \`src/routes/adminDashboard.ts\` with matching CSS from the mockup. Renders empty/fresh/stale states; alerts with severity + days-seen (from \`firstDetectedAt\`); four KPI tiles with directional deltas; top-5 queries; email delivery status; manual-actions reminder link.

### Pre-publish lint

- **`src/lint.ts`** — four pure rules: \`missing-excerpt\`, \`thin-content\`, \`duplicate-title\` (case-insensitive), \`poor-social-preview\`.
- \`saveUpdate\` surfaces warnings in the response when \`status==='published'\`. Non-blocking.
- Editor renders warnings in a yellow banner below the toolbar.

### Data-model additions (for the widget)

- \`GSCAlert.firstDetectedAt\` — preserved through graduation + continuation transitions so "Seen for N days" renders honestly.
- \`GSCEmailDelivery.lastProvider\` — type-comment documents \`null\` vs \`'none'\` semantics (resolves [#32](https://github.com/mannepanne/hultberg-org/issues/32)).

### Drive-bys

- Legacy \`format = "modules"\` removed from \`wrangler.toml\` (resolves [#35](https://github.com/mannepanne/hultberg-org/issues/35) — silences wrangler warning on every invocation).
- Spec moved to \`SPECIFICATIONS/ARCHIVE/\`; status set to Complete.
- \`REFERENCE/gsc-insights.md\` covers architecture, files, alert thresholds, ops tasks (smoke-test, key rotation, adding new alert types), and known gaps.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] 41 new tests (2 firstDetectedAt, 1 skipDispatch integration, 13 lint, 14 widget view-model, 6 status, 5 refresh)
- [x] Full suite: 482 passing. 2 pre-existing GA failures unchanged (tracked by [#34](https://github.com/mannepanne/hultberg-org/issues/34))
- [ ] **After merge & deploy:** sign in at \`/admin\`, visit \`/admin/dashboard\`. Expected initial state: widget shows "No data yet — the first poll runs daily at 08:00 UTC." Click **Refresh** → widget reloads with today's snapshot. Visit update editor and save a short update with empty excerpt → yellow warning banner appears.

## Not in this PR

Follow-up issues:
- [#30](https://github.com/mannepanne/hultberg-org/issues/30) — Email body enrichment
- [#31](https://github.com/mannepanne/hultberg-org/issues/31) — Threshold tuning (after 30 days of real data)
- [#33](https://github.com/mannepanne/hultberg-org/issues/33) — CF Email Sending ADR trust-surface note

🤖 Generated with [Claude Code](https://claude.com/claude-code)