### PR TITLE
escapeHtml: consolidate to utils + escape admin email + harden numerics

### DIFF
--- a/public/admin/gsc-widget.js
+++ b/public/admin/gsc-widget.js
@@ -54,7 +54,7 @@
         <span class="icon">${a.severity === 'high' ? '🔴' : '⚠️'}</span>
         <div class="body">
           <div class="title">${escapeHtml(a.subject)}</div>
-          <div class="meta">${escapeHtml(a.message)} Seen for ${a.daysSeen} ${a.daysSeen === 1 ? 'day' : 'days'}.${a.emailSent ? ' Email sent.' : ''}</div>
+          <div class="meta">${escapeHtml(a.message)} Seen for ${escapeHtml(String(a.daysSeen))} ${a.daysSeen === 1 ? 'day' : 'days'}.${a.emailSent ? ' Email sent.' : ''}</div>
         </div>
       </div>
     `).join('');
@@ -77,8 +77,8 @@
       <tr>
         <td class="query">${escapeHtml(q.query)}</td>
         <td class="metrics">
-          <span class="clicks">${q.clicks}</span>
-          ${q.impressions.toLocaleString()} impr · ${escapeHtml(q.ctrPct)} CTR · pos ${escapeHtml(q.position)}
+          <span class="clicks">${escapeHtml(String(q.clicks))}</span>
+          ${escapeHtml(Number(q.impressions).toLocaleString())} impr · ${escapeHtml(q.ctrPct)} CTR · pos ${escapeHtml(q.position)}
         </td>
       </tr>
     `).join('');

--- a/src/routes/adminDashboard.ts
+++ b/src/routes/adminDashboard.ts
@@ -5,17 +5,9 @@ import type { Env } from '@/types';
 import type { Update } from '@/types';
 import { requireAuth } from '@/auth';
 import { fetchAllUpdates } from '@/github';
+import { escapeHtml } from '@/utils';
 
 const CSP = "default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self';";
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
 
 function formatDate(isoDate: string): string {
   if (!isoDate) return '—';
@@ -174,7 +166,7 @@ function renderDashboard(email: string, updates: Update[]): string {
       <a href="/admin/dashboard" aria-current="page">Dashboard</a>
       <a href="/admin/now/edit">Now</a>
     </nav>
-    <span class="user">${email}</span>
+    <span class="user">${escapeHtml(email)}</span>
     <form method="POST" action="/admin/logout">
       <button type="submit">Logout</button>
     </form>


### PR DESCRIPTION
## Summary
- Removes the duplicate `escapeHtml` from `src/routes/adminDashboard.ts` and imports the canonical version from `src/utils.ts`
- Escapes `\${email}` in the admin dashboard header (was unescaped, JWT-trusted, but inconsistent with adminEditor)
- Wraps numeric GSC snapshot fields (`clicks`, `impressions`, `daysSeen`) in `escapeHtml(String(...))` as defence-in-depth — current code path is safe, but removes the assumption that KV always returns numbers

Closes #41, #42, #44.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — only failures are pre-existing GA tests (issue #34, addressed separately)
- [ ] Manual: load `/admin/dashboard` after deploy and confirm widget renders unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)