### PR TITLE
Fix test stability: drop stale GA assertions + Origin 403 coverage

### DIFF
--- a/tests/integration/nowPage.test.ts
+++ b/tests/integration/nowPage.test.ts
@@ -287,15 +287,6 @@ describe('GET /now', () => {
     expect(response.status).toBe(500);
   });
 
-  it('includes Google Analytics', async () => {
-    const request = new Request('http://localhost/now');
-    const response = await worker.fetch(request, mockEnv, mockCtx);
-    const html = await response.text();
-
-    expect(html).toContain('googletagmanager.com/gtag');
-    expect(html).toContain('G-D1L22CCJTJ');
-  });
-
   it('includes Cloudflare Web Analytics', async () => {
     const request = new Request('http://localhost/now');
     const response = await worker.fetch(request, mockEnv, mockCtx);

--- a/tests/integration/refreshGsc.test.ts
+++ b/tests/integration/refreshGsc.test.ts
@@ -99,6 +99,31 @@ describe('POST /admin/api/refresh-gsc', () => {
     expect(response.status).toBe(403);
   });
 
+  it('rejects requests with missing Origin header', async () => {
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    const request = new Request('http://localhost/admin/api/refresh-gsc', {
+      method: 'POST',
+      headers: {
+        Cookie: `auth_token=${jwt}`,
+      },
+    });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    expect(response.status).toBe(403);
+  });
+
+  it('rejects requests with empty-string Origin header', async () => {
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    const request = new Request('http://localhost/admin/api/refresh-gsc', {
+      method: 'POST',
+      headers: {
+        Cookie: `auth_token=${jwt}`,
+        Origin: '',
+      },
+    });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    expect(response.status).toBe(403);
+  });
+
   it('runs the poll and returns the new snapshot', async () => {
     const response = await worker.fetch(await authedRequest(), mockEnv, mockCtx);
     expect(response.status).toBe(200);

--- a/tests/integration/useOfAiPage.test.ts
+++ b/tests/integration/useOfAiPage.test.ts
@@ -69,15 +69,6 @@ describe('GET /use-of-ai', () => {
     expect(cacheControl).toBe('public, max-age=3600, s-maxage=3600');
   });
 
-  it('includes Google Analytics', async () => {
-    const request = new Request('http://localhost/use-of-ai');
-    const response = await worker.fetch(request, mockEnv, mockCtx);
-    const html = await response.text();
-
-    expect(html).toContain('googletagmanager.com/gtag');
-    expect(html).toContain('G-D1L22CCJTJ');
-  });
-
   it('includes Cloudflare Web Analytics', async () => {
     const request = new Request('http://localhost/use-of-ai');
     const response = await worker.fetch(request, mockEnv, mockCtx);


### PR DESCRIPTION
## Summary
- Removes two pre-existing failing assertions in `nowPage.test.ts` and `useOfAiPage.test.ts` that expected Google Analytics tags. GA was intentionally removed in commit f2c36fb; tests were missed. Cloudflare Web Analytics assertions remain.
- Adds two new assertions in `refreshGsc.test.ts`: missing `Origin` header → 403, empty-string `Origin` → 403. Mirrors the existing cross-origin case.
- Restores green coverage table on `npm run test:coverage` (was suppressed by failing tests).

Closes #34, #40.

## Test plan
- [x] `npm test` — 501/501 passing (was 499/501)
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)