### PR TITLE
GSC: snapshot source field + manual-refresh caveat

### DIFF
--- a/public/admin/dashboard.css
+++ b/public/admin/dashboard.css
@@ -57,6 +57,7 @@ h1 { font-size: 1.4em; margin: 0 0 20px; }
 .widget-header button.refresh:disabled { opacity: 0.6; cursor: wait; }
 .widget-body { padding: 16px 20px; }
 .widget-body.error { color: #721c24; background: #f8d7da; }
+.widget-caveat { padding: 8px 20px; font-size: 0.82em; color: #6c757d; background: #fafbfc; border-bottom: 1px solid #f1f3f5; font-style: italic; }
 .alerts { padding: 0 20px; }
 .alert { display: flex; align-items: flex-start; gap: 10px; padding: 12px 14px; border-radius: 4px; margin: 12px 0; font-size: 0.88em; }
 .alert .icon { font-size: 1.1em; line-height: 1; }

--- a/public/admin/gsc-widget.js
+++ b/public/admin/gsc-widget.js
@@ -39,6 +39,7 @@
           <span class="freshness ${vm.state === 'stale' ? 'stale' : ''}" ${freshnessAria}>${freshnessText}</span>
           <button class="refresh" type="button" id="gsc-refresh-btn">↻ Refresh</button>
         </div>
+        ${vm.caveat ? '<div class="widget-caveat" role="status">' + escapeHtml(vm.caveat) + '</div>' : ''}
         ${renderAlerts(vm.alerts)}
         ${vm.kpis.length > 0 ? renderKpis(vm.kpis) : ''}
         ${vm.topQueries.length > 0 ? renderQueries(vm.topQueries) : ''}
@@ -139,23 +140,28 @@
     }
     const ageHours = Math.max(0, Math.floor((now - new Date(snapshot.capturedAt)) / 3600000));
     const isStale = ageHours >= 36;
-    return {
+    var widgetAlerts = snapshot.alerts.map(function (a) {
+      // Back-compat: alerts written by PR #29's cron lack firstDetectedAt.
+      // Mirrors the fallback in src/gscWidgetViewModel.ts (which uses ??).
+      // We use || here intentionally — also catches accidentally-empty-string
+      // values (which `??` would let through and then `new Date('')` would
+      // produce Invalid Date).
+      var firstDetectedAt = a.firstDetectedAt || a.detectedAt || snapshot.capturedAt;
+      return {
+        type: a.type, severity: a.severity, subject: a.subject, message: a.message,
+        firstDetectedAt: firstDetectedAt,
+        daysSeen: Math.max(1, Math.floor((now - new Date(firstDetectedAt)) / 86400000) + 1),
+        emailSent: a.emailSent,
+      };
+    });
+    // Treat undefined source as 'cron' (back-compat).
+    var caveat = snapshot.source === 'manual' && widgetAlerts.some(function (a) { return !a.emailSent; })
+      ? 'Manual refresh — alerts emailed at next 08:00 UTC cron.'
+      : undefined;
+    var vm = {
       state: isStale ? 'stale' : 'fresh',
       freshnessLabel: freshnessLabel(ageHours),
-      alerts: snapshot.alerts.map(function (a) {
-        // Back-compat: alerts written by PR #29's cron lack firstDetectedAt.
-        // Mirrors the fallback in src/gscWidgetViewModel.ts (which uses ??).
-        // We use || here intentionally — also catches accidentally-empty-string
-        // values (which `??` would let through and then `new Date('')` would
-        // produce Invalid Date).
-        var firstDetectedAt = a.firstDetectedAt || a.detectedAt || snapshot.capturedAt;
-        return {
-          type: a.type, severity: a.severity, subject: a.subject, message: a.message,
-          firstDetectedAt: firstDetectedAt,
-          daysSeen: Math.max(1, Math.floor((now - new Date(firstDetectedAt)) / 86400000) + 1),
-          emailSent: a.emailSent,
-        };
-      }),
+      alerts: widgetAlerts,
       kpis: buildKpis(snapshot),
       topQueries: snapshot.performance.topQueries.map((q) => ({
         query: q.query, clicks: q.clicks, impressions: q.impressions,
@@ -164,6 +170,8 @@
       })),
       emailDelivery: buildEmailDelivery(snapshot, now),
     };
+    if (caveat !== undefined) vm.caveat = caveat;
+    return vm;
   }
 
   function freshnessLabel(hours) {

--- a/src/gscWidgetViewModel.ts
+++ b/src/gscWidgetViewModel.ts
@@ -39,6 +39,12 @@ export interface WidgetViewModel {
     label: string;             // "CF · 2h ago" / "Resend (fallback) · 1d ago" / "Never attempted" / "Both providers failed · Xh ago"
     kind: 'ok' | 'warn' | 'error' | 'idle';
   };
+  /**
+   * Optional advisory line shown above the alerts strip. Set when a manual
+   * refresh has graduated at least one alert that has not yet been emailed —
+   * tells the admin that dispatch will happen on the next 08:00 UTC cron.
+   */
+  caveat?: string;
 }
 
 const STALE_HOURS = 36;
@@ -63,24 +69,34 @@ export function renderViewModel(snapshot: GSCSnapshot | null, now: Date): Widget
   const ageHours = Math.max(0, Math.floor(ageMs / (60 * 60 * 1000)));
   const isStale = ageHours >= STALE_HOURS;
 
+  const widgetAlerts: WidgetAlert[] = snapshot.alerts.map((a) => {
+    // Back-compat: alerts written by PR #29's cron lack firstDetectedAt.
+    // Fall back to detectedAt, then to the snapshot's own capture time —
+    // anything but `undefined`, which would render as "Seen for NaN days".
+    const firstDetectedAt = a.firstDetectedAt ?? a.detectedAt ?? snapshot.capturedAt;
+    return {
+      type: a.type,
+      severity: a.severity,
+      subject: a.subject,
+      message: a.message,
+      firstDetectedAt,
+      daysSeen: daysBetween(new Date(firstDetectedAt), now),
+      emailSent: a.emailSent,
+    };
+  });
+
+  // Treat undefined source as 'cron' (back-compat with snapshots written
+  // before the source field existed).
+  const isManual = snapshot.source === 'manual';
+  const hasUnsentAlert = widgetAlerts.some((a) => !a.emailSent);
+  const caveat = isManual && hasUnsentAlert
+    ? 'Manual refresh — alerts emailed at next 08:00 UTC cron.'
+    : undefined;
+
   return {
     state: isStale ? 'stale' : 'fresh',
     freshnessLabel: freshnessLabel(ageHours),
-    alerts: snapshot.alerts.map((a) => {
-      // Back-compat: alerts written by PR #29's cron lack firstDetectedAt.
-      // Fall back to detectedAt, then to the snapshot's own capture time —
-      // anything but `undefined`, which would render as "Seen for NaN days".
-      const firstDetectedAt = a.firstDetectedAt ?? a.detectedAt ?? snapshot.capturedAt;
-      return {
-        type: a.type,
-        severity: a.severity,
-        subject: a.subject,
-        message: a.message,
-        firstDetectedAt,
-        daysSeen: daysBetween(new Date(firstDetectedAt), now),
-        emailSent: a.emailSent,
-      };
-    }),
+    alerts: widgetAlerts,
     kpis: buildKpis(snapshot),
     topQueries: snapshot.performance.topQueries.map((q) => ({
       query: q.query,
@@ -90,6 +106,7 @@ export function renderViewModel(snapshot: GSCSnapshot | null, now: Date): Widget
       position: q.position.toFixed(1),
     })),
     emailDelivery: buildEmailDelivery(snapshot, now),
+    ...(caveat !== undefined ? { caveat } : {}),
   };
 }
 

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -90,6 +90,7 @@ export async function runDailyPoll(
       lastSuccessAt: null,
       lastErrorAt: null,
     },
+    source: opts.skipDispatch ? 'manual' : 'cron',
   };
 
   if (!opts.skipDispatch) {

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -90,6 +90,7 @@ export async function runDailyPoll(
       lastSuccessAt: null,
       lastErrorAt: null,
     },
+    // skipDispatch undefined (cron path) → 'cron'; true (manual-refresh path) → 'manual'.
     source: opts.skipDispatch ? 'manual' : 'cron',
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,4 +200,14 @@ export interface GSCSnapshot {
   alerts: GSCAlert[];
   pendingAlerts: GSCPendingAlert[];
   emailDelivery: GSCEmailDelivery;
+  /**
+   * Which entry path produced this snapshot. `cron` runs dispatch alert
+   * emails; `manual` (admin refresh button) skips dispatch and relies on
+   * the next cron to deliver. The widget surfaces a caveat when a manual
+   * refresh graduates an alert so the admin understands the email lag.
+   *
+   * Optional for back-compat with snapshots written before this field
+   * existed; treat `undefined` as `'cron'` (the historic behaviour).
+   */
+  source?: 'cron' | 'manual';
 }

--- a/tests/integration/scheduled.test.ts
+++ b/tests/integration/scheduled.test.ts
@@ -127,6 +127,18 @@ describe('runDailyPoll', () => {
     expect(history).not.toBeNull();
   });
 
+  it('marks cron-path snapshots with source: cron', async () => {
+    mockGSCApi({ sitemaps: goodSitemapsResponse() });
+    const snapshot = await runDailyPoll(env, { now: NOW, siteUrl: SITE_URL });
+    expect(snapshot.source).toBe('cron');
+  });
+
+  it('marks manual-path snapshots with source: manual when skipDispatch is true', async () => {
+    mockGSCApi({ sitemaps: goodSitemapsResponse() });
+    const snapshot = await runDailyPoll(env, { now: NOW, siteUrl: SITE_URL, skipDispatch: true });
+    expect(snapshot.source).toBe('manual');
+  });
+
   it('includes top queries in the performance payload', async () => {
     mockGSCApi({
       sitemaps: goodSitemapsResponse(),

--- a/tests/unit/gscWidgetViewModel.test.ts
+++ b/tests/unit/gscWidgetViewModel.test.ts
@@ -254,3 +254,57 @@ describe('renderViewModel — email delivery', () => {
     expect(vm.emailDelivery.label).toContain('Both providers failed');
   });
 });
+
+describe('renderViewModel — manual-refresh caveat', () => {
+  const unsentAlert = {
+    type: 'indexed-drop' as const,
+    severity: 'high' as const,
+    subject: 'Indexed pages dropped 50%',
+    message: 'x',
+    firstDetectedAt: '2026-04-18T08:00:00Z',
+    detectedAt: '2026-04-18T08:00:00Z',
+    emailSent: false,
+  };
+  const sentAlert = { ...unsentAlert, emailSent: true };
+
+  it('sets caveat when source is manual AND there is at least one unsent alert', () => {
+    const vm = renderViewModel(
+      makeSnapshot({ source: 'manual', alerts: [unsentAlert] }),
+      NOW,
+    );
+    expect(vm.caveat).toBe('Manual refresh — alerts emailed at next 08:00 UTC cron.');
+  });
+
+  it('omits caveat when source is manual but all alerts are already sent', () => {
+    const vm = renderViewModel(
+      makeSnapshot({ source: 'manual', alerts: [sentAlert] }),
+      NOW,
+    );
+    expect(vm.caveat).toBeUndefined();
+  });
+
+  it('omits caveat when source is manual but there are no alerts', () => {
+    const vm = renderViewModel(
+      makeSnapshot({ source: 'manual', alerts: [] }),
+      NOW,
+    );
+    expect(vm.caveat).toBeUndefined();
+  });
+
+  it('omits caveat when source is cron (even with unsent alert — should not happen in practice but back-compat)', () => {
+    const vm = renderViewModel(
+      makeSnapshot({ source: 'cron', alerts: [unsentAlert] }),
+      NOW,
+    );
+    expect(vm.caveat).toBeUndefined();
+  });
+
+  it('treats undefined source as cron (back-compat with pre-#38 snapshots)', () => {
+    // No source field at all — historic snapshot from before this PR.
+    const vm = renderViewModel(
+      makeSnapshot({ alerts: [unsentAlert] }),
+      NOW,
+    );
+    expect(vm.caveat).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `source: 'cron' | 'manual'` to `GSCSnapshot` (`src/types.ts`)
- `runDailyPoll` sets it from `opts.skipDispatch`
- `WidgetViewModel` gains an optional `caveat` field; populated when a manual refresh has graduated an unsent alert
- Renderer (server + mirrored client copy) shows the caveat above the alerts strip
- New CSS class `.widget-caveat` in `public/admin/dashboard.css`

Closes #38. First of three PRs from `SPECIFICATIONS/gsc-insights-layer-2.md`.

## Back-compat
Snapshots from Layer 1 (#29, #36) lack the `source` field. View-model treats `undefined` as `cron` — historic behaviour preserved. Test covers this case explicitly.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 508/508 (+7 new: 5 view-model, 2 integration)
- [ ] Manual: trigger admin refresh that graduates an alert, confirm caveat strip appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)