### PR TITLE
GSC widget: manual-check recency + indexed-pages 28d delta

### DIFF
--- a/public/admin/gsc-widget.js
+++ b/public/admin/gsc-widget.js
@@ -336,9 +336,14 @@
     var link = document.getElementById('gsc-manual-check-link');
     if (!link) return;
     link.addEventListener('click', function () {
+      // keepalive ensures the request survives if the user middle-clicks
+      // and immediately closes the current tab. The link's target="_blank"
+      // otherwise leaves this tab running, so delivery is fine in the
+      // common case — keepalive covers the close-immediately edge.
       fetch('/admin/api/gsc-manual-check-clicked', {
         method: 'POST',
         credentials: 'same-origin',
+        keepalive: true,
       }).catch(function () { /* silent */ });
     });
   }

--- a/public/admin/gsc-widget.js
+++ b/public/admin/gsc-widget.js
@@ -95,10 +95,11 @@
 
   function renderFooter(vm) {
     const delivery = vm.emailDelivery;
+    const recency = vm.manualCheckRecency;
     return `
       <div class="gsc-footer">
         <span class="email-delivery ${escapeHtml(delivery.kind)}">Email delivery: ${escapeHtml(delivery.label)}</span>
-        <span class="manual-check">Manual actions &amp; security issues aren't in the GSC API — Google emails you directly. <a href="https://search.google.com/search-console/manual-actions" target="_blank" rel="noopener">Check Search Console ↗</a></span>
+        <span class="manual-check">${escapeHtml(recency.label)} — Google emails you directly for manual actions and security issues. <a id="gsc-manual-check-link" href="https://search.google.com/search-console/manual-actions" target="_blank" rel="noopener">Check Search Console ↗</a></span>
       </div>
     `;
   }
@@ -120,14 +121,36 @@
     if (!body.ok) {
       throw new Error(body.error || 'Unknown error');
     }
-    return computeViewModel(body.snapshot, new Date());
+    return computeViewModel(body.snapshot, new Date(), body.manualCheckLastClicked || null);
+  }
+
+  function buildManualCheckRecency(lastClicked, now) {
+    if (!lastClicked) {
+      return { label: 'Never checked in GSC UI', neverClicked: true };
+    }
+    var parsed = new Date(lastClicked);
+    if (isNaN(parsed.getTime())) {
+      return { label: 'Never checked in GSC UI', neverClicked: true };
+    }
+    var hours = Math.max(0, Math.floor((now - parsed) / 3600000));
+    if (hours < 24) {
+      return { label: 'Last checked in GSC UI: today', neverClicked: false };
+    }
+    var days = Math.floor(hours / 24);
+    return {
+      label: days === 1
+        ? 'Last checked in GSC UI: 1 day ago'
+        : 'Last checked in GSC UI: ' + days + ' days ago',
+      neverClicked: false,
+    };
   }
 
   // Mirror of src/gscWidgetViewModel.ts. Duplicated here because the worker
   // sends the raw snapshot (smaller payload + no server-side date baked in)
   // and the client computes the view with its own "now". Tests cover the
   // server-side copy; behaviour must match.
-  function computeViewModel(snapshot, now) {
+  function computeViewModel(snapshot, now, manualCheckLastClicked) {
+    var manualCheckRecency = buildManualCheckRecency(manualCheckLastClicked || null, now);
     if (!snapshot) {
       return {
         state: 'empty',
@@ -136,6 +159,7 @@
         kpis: [],
         topQueries: [],
         emailDelivery: { label: 'Never attempted', kind: 'idle' },
+        manualCheckRecency: manualCheckRecency,
       };
     }
     const ageHours = Math.max(0, Math.floor((now - new Date(snapshot.capturedAt)) / 3600000));
@@ -169,6 +193,7 @@
         position: q.position.toFixed(1),
       })),
       emailDelivery: buildEmailDelivery(snapshot, now),
+      manualCheckRecency: manualCheckRecency,
     };
     if (caveat !== undefined) vm.caveat = caveat;
     return vm;
@@ -192,11 +217,27 @@
     const deltaClass = (d) => d > 0.02 ? 'up' : d < -0.02 ? 'down' : 'flat';
     const fmt = (d) => d === 0 ? 'no change vs prior 28d' : ((d > 0 ? '+' : '') + Math.round(d * 100) + '% vs prior 28d');
     return [
-      { label: 'Indexed pages', value: String(snapshot.indexing.indexedCount), sub: '', deltaClass: 'flat' },
+      buildIndexedTile(snapshot.indexing.indexedCount, snapshot.indexing.priorPeriodIndexedCount),
       { label: 'Sitemap', value: submitted === 0 ? '0' : (indexed + ' / ' + submitted), sub: 'indexed / submitted', deltaClass: 'flat' },
       { label: 'Clicks (28d)', value: String(perf.totalClicks), sub: fmt(clicksDelta), deltaClass: deltaClass(clicksDelta) },
       { label: 'Impressions (28d)', value: String(perf.totalImpressions), sub: fmt(imprDelta), deltaClass: deltaClass(imprDelta) },
     ];
+  }
+
+  function buildIndexedTile(current, prior) {
+    if (prior === null || prior === undefined) {
+      return { label: 'Indexed pages', value: String(current), sub: '', deltaClass: 'flat' };
+    }
+    var diff = current - prior;
+    if (diff === 0) {
+      return { label: 'Indexed pages', value: String(current), sub: 'no change vs 28d ago', deltaClass: 'flat' };
+    }
+    return {
+      label: 'Indexed pages',
+      value: String(current),
+      sub: (diff > 0 ? '+' : '') + diff + ' vs 28d ago',
+      deltaClass: diff > 0 ? 'up' : 'down',
+    };
   }
 
   function buildEmailDelivery(snapshot, now) {
@@ -281,9 +322,25 @@
       root.innerHTML = render(vm);
       const btn = document.getElementById('gsc-refresh-btn');
       if (btn) btn.addEventListener('click', doRefresh);
+      wireManualCheckLink();
     } catch (err) {
       root.innerHTML = renderError(err.message);
     }
+  }
+
+  // Fire-and-forget POST that records the admin clicked the "Check Search
+  // Console" link. The link still navigates; KV write failure is silently
+  // swallowed (recency nudge is non-critical — better to lose a tick than
+  // interfere with the click).
+  function wireManualCheckLink() {
+    var link = document.getElementById('gsc-manual-check-link');
+    if (!link) return;
+    link.addEventListener('click', function () {
+      fetch('/admin/api/gsc-manual-check-clicked', {
+        method: 'POST',
+        credentials: 'same-origin',
+      }).catch(function () { /* silent */ });
+    });
   }
 
   // Test hook: a JSDOM test sets `window.__gscWidgetTest = {}` BEFORE this
@@ -297,6 +354,10 @@
       clearRefreshError: clearRefreshError,
       restoreRefreshButton: restoreRefreshButton,
       computeViewModel: computeViewModel,
+      buildManualCheckRecency: buildManualCheckRecency,
+      buildIndexedTile: buildIndexedTile,
+      wireManualCheckLink: wireManualCheckLink,
+      render: render,
     };
   } else if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', load);

--- a/src/gscWidgetViewModel.ts
+++ b/src/gscWidgetViewModel.ts
@@ -40,6 +40,16 @@ export interface WidgetViewModel {
     kind: 'ok' | 'warn' | 'error' | 'idle';
   };
   /**
+   * Recency nudge for the "Check Search Console" link. Rendered in the
+   * footer as either "Last checked in GSC UI: N days ago" or "Never
+   * checked" — encourages the admin to periodically visit GSC directly
+   * for manual actions / security issues that aren't in the API.
+   */
+  manualCheckRecency: {
+    label: string;
+    neverClicked: boolean;
+  };
+  /**
    * Optional advisory line shown above the alerts strip. Set when a manual
    * refresh has graduated at least one alert that has not yet been emailed —
    * tells the admin that dispatch will happen on the next 08:00 UTC cron.
@@ -52,8 +62,18 @@ const STALE_HOURS = 36;
 /**
  * Build a view-model from a snapshot + current time.
  * If snapshot is null (no data yet), returns the empty state.
+ *
+ * `manualCheckLastClicked` is the ISO timestamp of the last time the admin
+ * clicked the "Check Search Console" link in the widget footer, or `null`
+ * if never clicked (fresh install, or never-clicked state).
  */
-export function renderViewModel(snapshot: GSCSnapshot | null, now: Date): WidgetViewModel {
+export function renderViewModel(
+  snapshot: GSCSnapshot | null,
+  now: Date,
+  manualCheckLastClicked: string | null = null,
+): WidgetViewModel {
+  const manualCheckRecency = buildManualCheckRecency(manualCheckLastClicked, now);
+
   if (!snapshot) {
     return {
       state: 'empty',
@@ -62,6 +82,7 @@ export function renderViewModel(snapshot: GSCSnapshot | null, now: Date): Widget
       kpis: [],
       topQueries: [],
       emailDelivery: { label: 'Never attempted', kind: 'idle' },
+      manualCheckRecency,
     };
   }
 
@@ -106,7 +127,33 @@ export function renderViewModel(snapshot: GSCSnapshot | null, now: Date): Widget
       position: q.position.toFixed(1),
     })),
     emailDelivery: buildEmailDelivery(snapshot, now),
+    manualCheckRecency,
     ...(caveat !== undefined ? { caveat } : {}),
+  };
+}
+
+function buildManualCheckRecency(
+  lastClicked: string | null,
+  now: Date,
+): WidgetViewModel['manualCheckRecency'] {
+  if (!lastClicked) {
+    return { label: 'Never checked in GSC UI', neverClicked: true };
+  }
+  const parsed = new Date(lastClicked);
+  if (Number.isNaN(parsed.getTime())) {
+    // Corrupt KV value — fall back to "never" rather than crash.
+    return { label: 'Never checked in GSC UI', neverClicked: true };
+  }
+  const hours = Math.max(0, Math.floor((now.getTime() - parsed.getTime()) / (60 * 60 * 1000)));
+  if (hours < 24) {
+    return { label: 'Last checked in GSC UI: today', neverClicked: false };
+  }
+  const days = Math.floor(hours / 24);
+  return {
+    label: days === 1
+      ? 'Last checked in GSC UI: 1 day ago'
+      : `Last checked in GSC UI: ${days} days ago`,
+    neverClicked: false,
   };
 }
 
@@ -135,13 +182,16 @@ function buildKpis(snapshot: GSCSnapshot): WidgetKpiTile[] {
     ? (snapshot.performance.totalImpressions - snapshot.performance.priorPeriodImpressions) / snapshot.performance.priorPeriodImpressions
     : 0;
 
+  // Indexed-pages delta uses an ABSOLUTE diff (e.g. "+2 vs 28d ago"), not a
+  // percentage like Clicks/Impressions. The absolute number is more
+  // intuitive for a small indexed count (20 pages → +2 reads clearer than
+  // "+10%"). When the 28d-ago snapshot is absent (cold start, first 28 days
+  // of data), the sub is empty and deltaClass is flat.
+  const priorIndexed = snapshot.indexing.priorPeriodIndexedCount;
+  const indexedTile = buildIndexedTile(snapshot.indexing.indexedCount, priorIndexed);
+
   return [
-    {
-      label: 'Indexed pages',
-      value: String(snapshot.indexing.indexedCount),
-      sub: '',
-      deltaClass: 'flat',
-    },
+    indexedTile,
     {
       label: 'Sitemap',
       value: submitted === 0 ? '0' : `${indexed} / ${submitted}`,
@@ -161,6 +211,36 @@ function buildKpis(snapshot: GSCSnapshot): WidgetKpiTile[] {
       deltaClass: deltaClassFor(impressionsDelta),
     },
   ];
+}
+
+function buildIndexedTile(
+  current: number,
+  prior: number | null | undefined,
+): WidgetKpiTile {
+  if (prior === null || prior === undefined) {
+    return {
+      label: 'Indexed pages',
+      value: String(current),
+      sub: '',
+      deltaClass: 'flat',
+    };
+  }
+  const diff = current - prior;
+  let sub: string;
+  let deltaClass: 'up' | 'down' | 'flat';
+  if (diff === 0) {
+    sub = 'no change vs 28d ago';
+    deltaClass = 'flat';
+  } else {
+    sub = `${diff > 0 ? '+' : ''}${diff} vs 28d ago`;
+    deltaClass = diff > 0 ? 'up' : 'down';
+  }
+  return {
+    label: 'Indexed pages',
+    value: String(current),
+    sub,
+    deltaClass,
+  };
 }
 
 function formatDeltaSub(delta: number, suffix: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { handleSitemap } from './routes/sitemap';
 import { handleGscDebug } from './routes/gscDebug';
 import { handleGscStatus } from './routes/gscStatus';
 import { handleRefreshGsc } from './routes/refreshGsc';
+import { handleGscManualCheckClicked } from './routes/gscManualCheckClicked';
 import { handleScheduled } from './scheduled';
 import { handleAdminLogin } from './routes/adminLogin';
 import { handleAdminLogout } from './routes/adminLogout';
@@ -122,6 +123,13 @@ export default {
     // delivery path. Used by the dashboard "Refresh" button.
     if (url.pathname === '/admin/api/refresh-gsc' && request.method === 'POST') {
       return handleRefreshGsc(request, env);
+    }
+
+    // API: POST /admin/api/gsc-manual-check-clicked (authenticated)
+    // Records that the admin clicked the "Check Search Console" link —
+    // drives the "Last checked in GSC UI" recency nudge.
+    if (url.pathname === '/admin/api/gsc-manual-check-clicked' && request.method === 'POST') {
+      return handleGscManualCheckClicked(request, env);
     }
 
     // Editor: GET /admin/now/edit

--- a/src/routes/gscManualCheckClicked.ts
+++ b/src/routes/gscManualCheckClicked.ts
@@ -1,0 +1,38 @@
+// ABOUT: POST /admin/api/gsc-manual-check-clicked — records that the admin
+// ABOUT: clicked the "Check Search Console" link in the widget footer. The
+// ABOUT: timestamp drives the "Last checked in GSC UI: N days ago" recency
+// ABOUT: nudge rendered by the widget.
+
+import type { Env } from '@/types';
+import { requireAuth } from '@/auth';
+
+const KV_KEY = 'manual-check:lastClicked';
+
+export async function handleGscManualCheckClicked(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  if (origin !== new URL(request.url).origin) {
+    return json({ ok: false, error: 'Forbidden' }, 403);
+  }
+
+  const authResult = await requireAuth(request, env);
+  if (authResult instanceof Response) {
+    return authResult;
+  }
+
+  if (!env.GSC_KV) {
+    return json({ ok: false, error: 'GSC_KV binding not configured' }, 500);
+  }
+
+  await env.GSC_KV.put(KV_KEY, new Date().toISOString());
+  return json({ ok: true });
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'private, no-store',
+    },
+  });
+}

--- a/src/routes/gscStatus.ts
+++ b/src/routes/gscStatus.ts
@@ -14,11 +14,14 @@ export async function handleGscStatus(request: Request, env: Env): Promise<Respo
     return json({ ok: false, error: 'GSC_KV binding not configured' }, 500);
   }
 
-  const raw = await env.GSC_KV.get('status:latest');
+  const [raw, manualCheckLastClicked] = await Promise.all([
+    env.GSC_KV.get('status:latest'),
+    env.GSC_KV.get('manual-check:lastClicked'),
+  ]);
   if (!raw) {
     // No snapshot yet (cron hasn't fired for the first time). Not an error —
     // widget renders an empty state from this.
-    return json({ ok: true, snapshot: null });
+    return json({ ok: true, snapshot: null, manualCheckLastClicked });
   }
 
   let snapshot: GSCSnapshot;
@@ -28,7 +31,7 @@ export async function handleGscStatus(request: Request, env: Env): Promise<Respo
     return json({ ok: false, error: 'Corrupt snapshot in KV' }, 500);
   }
 
-  return json({ ok: true, snapshot });
+  return json({ ok: true, snapshot, manualCheckLastClicked });
 }
 
 function json(body: unknown, status = 200): Response {

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -61,13 +61,15 @@ export async function runDailyPoll(
 
   const client = GSCClient.fromSecret(env.GSC_SERVICE_ACCOUNT_JSON, siteUrl);
 
-  const [sitemaps, performance, weekAgoSnapshot] = await Promise.all([
+  const [sitemaps, performance, weekAgoSnapshot, fourWeeksAgoSnapshot] = await Promise.all([
     fetchSitemaps(client),
     fetchPerformance(client, now),
     loadHistorySnapshot(kv, daysAgo(now, 7)),
+    loadHistorySnapshot(kv, daysAgo(now, 28)),
   ]);
 
   const indexedCount = sitemaps.reduce((sum, sm) => sum + sm.indexed, 0);
+  const priorPeriodIndexedCount = fourWeeksAgoSnapshot?.indexing.indexedCount ?? null;
   const previousLatest = await loadLatestSnapshot(kv);
 
   const { alerts, pendingAlerts } = resolveAlerts({
@@ -81,7 +83,7 @@ export async function runDailyPoll(
     capturedAt: now.toISOString(),
     siteUrl,
     sitemaps,
-    indexing: { indexedCount },
+    indexing: { indexedCount, priorPeriodIndexedCount },
     performance,
     alerts,
     pendingAlerts,

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,6 +195,14 @@ export interface GSCSnapshot {
   sitemaps: GSCSitemapStatus[];
   indexing: {
     indexedCount: number;
+    /**
+     * Indexed count from the 28-day-ago history snapshot, or `null` if no
+     * history snapshot exists for that date. Drives the "+2 vs 28d ago"
+     * delta on the Indexed tile.
+     * Optional for back-compat with snapshots written before this field
+     * existed; treat `undefined` as `null`.
+     */
+    priorPeriodIndexedCount?: number | null;
   };
   performance: GSCPerformance;
   alerts: GSCAlert[];

--- a/tests/integration/gscManualCheckClicked.test.ts
+++ b/tests/integration/gscManualCheckClicked.test.ts
@@ -1,0 +1,99 @@
+// ABOUT: Integration tests for POST /admin/api/gsc-manual-check-clicked.
+// ABOUT: Covers auth, Origin check, and KV write of the last-clicked timestamp.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import worker from '@/index';
+import { createMockEnv } from '../mocks/env';
+import { createMockContext } from '../mocks/context';
+import { generateJWT } from '@/auth';
+
+describe('POST /admin/api/gsc-manual-check-clicked', () => {
+  let mockEnv: any;
+  let mockCtx: ExecutionContext;
+
+  beforeEach(() => {
+    mockEnv = createMockEnv({
+      ADMIN_EMAIL: 'magnus@example.com',
+    });
+    mockCtx = createMockContext();
+  });
+
+  async function authedRequest(overrides: RequestInit = {}) {
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    return new Request('http://localhost/admin/api/gsc-manual-check-clicked', {
+      method: 'POST',
+      headers: {
+        Cookie: `auth_token=${jwt}`,
+        Origin: 'http://localhost',
+        ...(overrides.headers as Record<string, string> ?? {}),
+      },
+      ...overrides,
+    });
+  }
+
+  it('redirects unauthenticated requests', async () => {
+    const request = new Request('http://localhost/admin/api/gsc-manual-check-clicked', {
+      method: 'POST',
+      headers: { Origin: 'http://localhost' },
+    });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    expect([302, 401]).toContain(response.status);
+  });
+
+  it('rejects cross-origin requests', async () => {
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    const request = new Request('http://localhost/admin/api/gsc-manual-check-clicked', {
+      method: 'POST',
+      headers: {
+        Cookie: `auth_token=${jwt}`,
+        Origin: 'http://evil.example.com',
+      },
+    });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    expect(response.status).toBe(403);
+  });
+
+  it('rejects missing Origin header', async () => {
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    const request = new Request('http://localhost/admin/api/gsc-manual-check-clicked', {
+      method: 'POST',
+      headers: { Cookie: `auth_token=${jwt}` },
+    });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    expect(response.status).toBe(403);
+  });
+
+  it('writes manual-check:lastClicked to KV with the current ISO timestamp', async () => {
+    const before = Date.now();
+    const response = await worker.fetch(await authedRequest(), mockEnv, mockCtx);
+    const after = Date.now();
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+
+    const written = await mockEnv.GSC_KV.get('manual-check:lastClicked');
+    expect(written).not.toBeNull();
+    const parsed = new Date(written!).getTime();
+    expect(parsed).toBeGreaterThanOrEqual(before);
+    expect(parsed).toBeLessThanOrEqual(after);
+  });
+
+  it('overwrites an existing value on subsequent clicks', async () => {
+    await mockEnv.GSC_KV.put('manual-check:lastClicked', '2026-01-01T00:00:00Z');
+    const response = await worker.fetch(await authedRequest(), mockEnv, mockCtx);
+    expect(response.status).toBe(200);
+
+    const written = await mockEnv.GSC_KV.get('manual-check:lastClicked');
+    expect(written).not.toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('returns 500 when GSC_KV is not bound', async () => {
+    const bareEnv = createMockEnv({
+      ADMIN_EMAIL: 'magnus@example.com',
+      GSC_KV: undefined,
+    });
+    const response = await worker.fetch(await authedRequest(), bareEnv, mockCtx);
+    expect(response.status).toBe(500);
+  });
+});

--- a/tests/integration/gscStatus.test.ts
+++ b/tests/integration/gscStatus.test.ts
@@ -92,6 +92,32 @@ describe('GET /admin/api/gsc-status', () => {
     expect(response.status).toBe(500);
   });
 
+  it('returns manualCheckLastClicked alongside snapshot when KV key is set', async () => {
+    await mockEnv.GSC_KV.put('status:latest', JSON.stringify(SAMPLE_SNAPSHOT));
+    await mockEnv.GSC_KV.put('manual-check:lastClicked', '2026-04-10T12:00:00Z');
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    const request = new Request('http://localhost/admin/api/gsc-status', {
+      method: 'GET',
+      headers: { Cookie: `auth_token=${jwt}` },
+    });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    expect(response.status).toBe(200);
+    const body = await response.json() as { manualCheckLastClicked: string | null };
+    expect(body.manualCheckLastClicked).toBe('2026-04-10T12:00:00Z');
+  });
+
+  it('returns manualCheckLastClicked: null when KV key is absent', async () => {
+    await mockEnv.GSC_KV.put('status:latest', JSON.stringify(SAMPLE_SNAPSHOT));
+    const jwt = await generateJWT(mockEnv, 'test@example.com');
+    const request = new Request('http://localhost/admin/api/gsc-status', {
+      method: 'GET',
+      headers: { Cookie: `auth_token=${jwt}` },
+    });
+    const response = await worker.fetch(request, mockEnv, mockCtx);
+    const body = await response.json() as { manualCheckLastClicked: string | null };
+    expect(body.manualCheckLastClicked).toBeNull();
+  });
+
   it('sets a no-store cache-control header (admin data, per-user)', async () => {
     const jwt = await generateJWT(mockEnv, 'test@example.com');
     const request = new Request('http://localhost/admin/api/gsc-status', {

--- a/tests/unit/gscWidgetViewModel.test.ts
+++ b/tests/unit/gscWidgetViewModel.test.ts
@@ -255,6 +255,95 @@ describe('renderViewModel — email delivery', () => {
   });
 });
 
+describe('renderViewModel — manual-check recency', () => {
+  it('reports "Never checked" when lastClicked is null', () => {
+    const vm = renderViewModel(makeSnapshot(), NOW, null);
+    expect(vm.manualCheckRecency.neverClicked).toBe(true);
+    expect(vm.manualCheckRecency.label).toBe('Never checked in GSC UI');
+  });
+
+  it('reports "today" for a click <24h ago', () => {
+    const vm = renderViewModel(makeSnapshot(), NOW, '2026-04-18T08:00:00Z'); // 4h ago
+    expect(vm.manualCheckRecency.neverClicked).toBe(false);
+    expect(vm.manualCheckRecency.label).toBe('Last checked in GSC UI: today');
+  });
+
+  it('reports "1 day ago" for a click 1 day old', () => {
+    const vm = renderViewModel(makeSnapshot(), NOW, '2026-04-17T08:00:00Z'); // 28h ago
+    expect(vm.manualCheckRecency.label).toBe('Last checked in GSC UI: 1 day ago');
+  });
+
+  it('reports "N days ago" for older clicks', () => {
+    const vm = renderViewModel(makeSnapshot(), NOW, '2026-04-06T12:00:00Z'); // 12 days ago
+    expect(vm.manualCheckRecency.label).toBe('Last checked in GSC UI: 12 days ago');
+  });
+
+  it('falls back to "Never checked" for corrupt KV values', () => {
+    const vm = renderViewModel(makeSnapshot(), NOW, 'not-a-date');
+    expect(vm.manualCheckRecency.neverClicked).toBe(true);
+  });
+
+  it('is also emitted in the empty state (no snapshot)', () => {
+    const vm = renderViewModel(null, NOW, '2026-04-10T12:00:00Z');
+    expect(vm.state).toBe('empty');
+    expect(vm.manualCheckRecency.neverClicked).toBe(false);
+    expect(vm.manualCheckRecency.label).toContain('8 days ago');
+  });
+});
+
+describe('renderViewModel — indexed-pages delta', () => {
+  it('shows empty sub with flat delta when priorPeriodIndexedCount is null', () => {
+    const vm = renderViewModel(
+      makeSnapshot({ indexing: { indexedCount: 18, priorPeriodIndexedCount: null } }),
+      NOW,
+    );
+    const indexed = vm.kpis.find((k) => k.label === 'Indexed pages')!;
+    expect(indexed.value).toBe('18');
+    expect(indexed.sub).toBe('');
+    expect(indexed.deltaClass).toBe('flat');
+  });
+
+  it('treats undefined priorPeriodIndexedCount as null (back-compat)', () => {
+    const vm = renderViewModel(
+      makeSnapshot({ indexing: { indexedCount: 18 } }),
+      NOW,
+    );
+    const indexed = vm.kpis.find((k) => k.label === 'Indexed pages')!;
+    expect(indexed.sub).toBe('');
+    expect(indexed.deltaClass).toBe('flat');
+  });
+
+  it('shows +N with up-delta when current > prior', () => {
+    const vm = renderViewModel(
+      makeSnapshot({ indexing: { indexedCount: 20, priorPeriodIndexedCount: 18 } }),
+      NOW,
+    );
+    const indexed = vm.kpis.find((k) => k.label === 'Indexed pages')!;
+    expect(indexed.sub).toBe('+2 vs 28d ago');
+    expect(indexed.deltaClass).toBe('up');
+  });
+
+  it('shows -N with down-delta when current < prior', () => {
+    const vm = renderViewModel(
+      makeSnapshot({ indexing: { indexedCount: 15, priorPeriodIndexedCount: 18 } }),
+      NOW,
+    );
+    const indexed = vm.kpis.find((k) => k.label === 'Indexed pages')!;
+    expect(indexed.sub).toBe('-3 vs 28d ago');
+    expect(indexed.deltaClass).toBe('down');
+  });
+
+  it('shows "no change" when current equals prior', () => {
+    const vm = renderViewModel(
+      makeSnapshot({ indexing: { indexedCount: 18, priorPeriodIndexedCount: 18 } }),
+      NOW,
+    );
+    const indexed = vm.kpis.find((k) => k.label === 'Indexed pages')!;
+    expect(indexed.sub).toBe('no change vs 28d ago');
+    expect(indexed.deltaClass).toBe('flat');
+  });
+});
+
 describe('renderViewModel — manual-refresh caveat', () => {
   const unsentAlert = {
     type: 'indexed-drop' as const,


### PR DESCRIPTION
## Summary

Two pieces of mockup adherence missing from PR #36's widget, bundled into one PR per the Layer 2 spec.

**Part 1 — GSC manual-check recency tracking**
- New endpoint `POST /admin/api/gsc-manual-check-clicked` (auth + Origin-checked) writes `manual-check:lastClicked` to `GSC_KV`
- `GET /admin/api/gsc-status` extended to return `manualCheckLastClicked`
- View-model gains `manualCheckRecency: { label, neverClicked }`
- Widget footer link now shows "Last checked in GSC UI: N days ago" / "Never checked in GSC UI"
- Click handler is fire-and-forget — KV failures never interfere with the navigation

**Part 2 — Indexed-pages 28d delta**
- `runDailyPoll` loads the 28-day-ago history snapshot and stores its `indexedCount` into the new snapshot as `indexing.priorPeriodIndexedCount`
- Indexed tile now shows "+2 vs 28d ago" / "-3 vs 28d ago" / "no change vs 28d ago" with correct delta class
- Uses absolute diff (not percentage) — reads better at small counts

Closes #39. Second of three PRs from `SPECIFICATIONS/gsc-insights-layer-2.md`.

## Back-compat
- Snapshots from Layer 1 lack `indexing.priorPeriodIndexedCount`. View-model treats `undefined` and `null` both as "no prior data" and falls back to the empty-sub flat tile. Test covers both cases.
- `manualCheckLastClicked` is `null` when the KV key is absent — view-model renders "Never checked in GSC UI".

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 527/527 (+19 new: 11 view-model, 6 integration for the new endpoint, 2 for extended gsc-status)
- [ ] Manual: load `/admin/dashboard`, confirm "Never checked" appears before any click; click the link, reload, confirm "today"
- [ ] Manual: after 28 days of cron data, confirm Indexed tile shows a real delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)