### PR TITLE
Add QRious Specimens link to homepage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,6 +34,10 @@
     (or am about to maybe love, or not)
 </p>
 <p>
+    or scan <a href="https://qrious.hultberg.org">QRious Specimens</a>, a digital cabinet of curiosities
+    (QR codes optional, curiosity required)
+</p>
+<p>
     or check out <a href="https://ansible.hultberg.org">my AI powered companion to Readwise Reader</a>
     to separate signal from noise
 </p>


### PR DESCRIPTION
## Summary
- Adds a link to https://qrious.hultberg.org below the restaurants line on the homepage
- Matches the existing lowercase, "or…"-prefixed style with a comedic parenthetical aside ("QR codes optional, curiosity required")

## Test plan
- [ ] Visit `/` locally (or after deploy) and confirm the new line renders between the restaurants and Ansible links
- [ ] Click through to https://qrious.hultberg.org and confirm the link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)