### PR TITLE
Bump deploy workflow actions ahead of Node 20 deprecation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,12 +11,12 @@
       name: Deploy
       steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
 
         - name: Setup Node.js
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@v6
           with:
-            node-version: '20'
+            node-version: '22'
             cache: 'npm'
 
         - name: Install dependencies
@@ -26,7 +26,7 @@
           run: node scripts/generate-index.js
 
         - name: Deploy to Cloudflare Workers
-          uses: cloudflare/wrangler-action@v3
+          uses: cloudflare/wrangler-action@v3.15.0
           with:
             apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
             accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- GitHub is forcing runner actions onto Node 24 by **June 2, 2026** and removing Node 20 entirely on **September 16, 2026** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/))
- Bumps the deploy workflow ahead of that deadline so we don't get bitten by a surprise breakage

## Changes
- `actions/checkout` v4 → v6 (Node 20 → Node 24)
- `actions/setup-node` v4 → v6 (Node 20 → Node 24)
- `cloudflare/wrangler-action` v3 → v3.15.0 (latest v3, already Node 24 — pinned to minor for stability)
- `node-version` 20 → 22 (Node 20 hit EOL in April 2026; 22 is current LTS)

## Test plan
- [ ] Watch the deploy workflow on merge — `npm ci`, `generate-index.js`, and `wrangler deploy` all succeed
- [ ] Confirm the Node 20 deprecation annotation no longer appears in the run summary
- [ ] Spot-check the live site after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)