### PR TITLE
Add Hnefatafl link to homepage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,7 @@
 <p>if you came here <a href="/2005/11/recipe_sharing_.html">looking for the recipe for the Swedish classic "Flying Jacob", you struck gold</a>!</p>
 <p>see what I'm up to <a href="/now">/now</a></p>
 <p>or read my <a href="/updates">/updates</a></p>
+<p>or play <a href="https://hnefatafl.hultberg.org/" target="_blank">the Viking board game Hnefatafl</a>, lovingly restored from the Copenhagen rules</p>
 <p>
     or browse a
     <a href="https://restaurants.hultberg.org">curated selection of restaurants I love</a>


### PR DESCRIPTION
## Summary
- Adds a line linking to https://hnefatafl.hultberg.org/ below the `/updates` line on the homepage
- Link text: "the Viking board game Hnefatafl", opens in a new tab
- Full sentence: "or play the Viking board game Hnefatafl, lovingly restored from the Copenhagen rules"

## Test plan
- [ ] Visit homepage and verify the new line appears after "or read my /updates"
- [ ] Click the link and confirm it opens hnefatafl.hultberg.org in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)