### PR TITLE
Add security response headers across all responses

### DIFF
--- a/REFERENCE/blog-security.md
+++ b/REFERENCE/blog-security.md
@@ -247,19 +247,23 @@ Content-Security-Policy:
 ```
 Content-Security-Policy:
   default-src 'self';
-  script-src 'self';
+  script-src 'self' https://static.cloudflareinsights.com;
   style-src 'self' 'unsafe-inline';
   img-src 'self';
-  connect-src 'self';
+  connect-src 'self' https://cloudflareinsights.com;
   frame-ancestors 'none';
   base-uri 'self';
 ```
 
+This is also the `DEFAULT_CSP` applied by `withSecurityHeaders()` to any
+response that does not set its own policy (see "Global Security Headers").
+
 **Stricter policy for public:**
-- No external CDNs
+- Only the Cloudflare Web Analytics beacon is allowed as an external script/connect origin
+- No other external CDNs
 - No inline scripts
 - Only inline styles (for simple formatting)
-- Blocks all XSS attempts via CSP layer
+- Blocks XSS attempts via the CSP layer
 
 ### Implementation
 

--- a/REFERENCE/blog-security.md
+++ b/REFERENCE/blog-security.md
@@ -285,6 +285,45 @@ return new Response(html, {
 
 ---
 
+## Global Security Headers
+
+Beyond CSP, every response carries a standard set of hardening headers. These
+are applied centrally rather than per-route.
+
+### Worker responses
+
+`src/index.ts` routes each request through `handleRequest()` and wraps the
+result in `withSecurityHeaders()` (`src/securityHeaders.ts`) at the single exit
+point. The wrapper:
+
+- Forces `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`,
+  `Referrer-Policy: strict-origin-when-cross-origin`, and a restrictive
+  `Permissions-Policy` on every response.
+- Adds a default CSP **only when the route did not set its own** — the
+  route-specific CSPs (admin, `/now`, etc.) are preserved untouched.
+
+This is why the homepage (`/`, served via `env.ASSETS.fetch()` under
+`run_worker_first`) is now hardened: the wrapper sees the asset response before
+it leaves the Worker.
+
+### Static assets that bypass the Worker
+
+Legacy `/2005/` pages, images, and error pages are served directly by
+Cloudflare Assets — the Worker never runs, so `withSecurityHeaders()` cannot
+reach them. `public/_headers` supplies the same four headers for those paths.
+It deliberately omits CSP so the archived pages' third-party widgets keep
+working. (Cloudflare's static-asset `_headers` file does **not** apply to
+Worker-generated responses, which is why both layers exist.)
+
+### HSTS
+
+`Strict-Transport-Security` is **not** set in code — Cloudflare's edge already
+injects it on this zone. Setting it again would duplicate the header. To
+lengthen its `max-age` (currently 30 days) or add `preload`, change it in the
+Cloudflare dashboard under SSL/TLS → Edge Certificates → HSTS.
+
+---
+
 ## Rate Limiting
 
 ### Admin API Endpoints

--- a/REFERENCE/blog-security.md
+++ b/REFERENCE/blog-security.md
@@ -303,8 +303,8 @@ point. The wrapper:
   route-specific CSPs (admin, `/now`, etc.) are preserved untouched.
 
 This is why the homepage (`/`, served via `env.ASSETS.fetch()` under
-`run_worker_first`) is now hardened: the wrapper sees the asset response before
-it leaves the Worker.
+`run_worker_first`) is hardened: the wrapper sees the asset response before it
+leaves the Worker.
 
 ### Static assets that bypass the Worker
 

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,13 @@
+# Security headers for static assets served directly by Cloudflare Assets
+# (legacy pages, images, error pages) — these bypass the Worker, so the
+# withSecurityHeaders() wrapper in src/index.ts never sees them.
+#
+# Deliberately no Content-Security-Policy here: the archived /2005/ pages rely
+# on third-party widgets (analytics, Twitter, Goodreads) that a strict CSP
+# would block. Strict-Transport-Security is omitted because Cloudflare's edge
+# already injects it on this zone.
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), usb=()

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,9 +31,22 @@ import { handleListNowSnapshots } from './routes/listNowSnapshots';
 import { handleDeleteNowSnapshot } from './routes/deleteNowSnapshot';
 import { handleUseOfAiPage } from './routes/useOfAiPage';
 import { GITHUB_REPO } from './github';
+import { withSecurityHeaders } from './securityHeaders';
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    // Single exit point: route the request, then apply security headers to
+    // every response (homepage, dynamic routes, 404). Routes that set their
+    // own CSP keep it; the rest get the default policy from withSecurityHeaders.
+    return withSecurityHeaders(await handleRequest(request, env, ctx));
+  },
+
+  // Cron trigger — runs daily per wrangler.toml. Wraps runDailyPoll in
+  // ctx.waitUntil so async work completes after the outer handler returns.
+  scheduled: handleScheduled,
+};
+
+async function handleRequest(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
     // Legacy WordPress query-string URLs return 410 Gone so search engines
@@ -260,9 +273,4 @@ export default {
         'Content-Type': 'text/html',
       },
     });
-  },
-
-  // Cron trigger — runs daily per wrangler.toml. Wraps runDailyPoll in
-  // ctx.waitUntil so async work completes after the outer handler returns.
-  scheduled: handleScheduled,
-};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,7 +260,7 @@ async function handleRequest(request: Request, env: Env, ctx: ExecutionContext):
             <p>← <a href="/">Home</a> | <a href="/updates">Updates</a> | <a href="/now">Now</a> | <a href="https://www.linkedin.com/in/hultberg/" target="_blank" rel="noopener noreferrer">LinkedIn</a> | <a href="https://github.com/mannepanne" target="_blank" rel="noopener noreferrer">GitHub</a> | <a href="/use-of-ai">Use of AI</a></p>
             <img src="/errors/bazinga.gif" alt="bazinga!" /><br /><br />
             sorry, the page or file you are looking for isn't here...<br />
-            <a href="/" onclick="history.back(); return false;">go back from whence you came</a>, or tell me what a klutz I am by messaging me on
+            <a href="/">go back home</a>, or tell me what a klutz I am by messaging me on
             <a href="https://uk.linkedin.com/in/hultberg" target="_blank" rel="noopener noreferrer">LinkedIn</a>
             <p>← <a href="/">Home</a> | <a href="/updates">Updates</a> | <a href="/now">Now</a> | <a href="https://www.linkedin.com/in/hultberg/" target="_blank" rel="noopener noreferrer">LinkedIn</a> | <a href="https://github.com/mannepanne" target="_blank" rel="noopener noreferrer">GitHub</a> | <a href="/use-of-ai">Use of AI</a></p>
         </div>

--- a/src/securityHeaders.ts
+++ b/src/securityHeaders.ts
@@ -1,0 +1,43 @@
+// ABOUT: Centralised security response headers for every Worker response.
+// ABOUT: Adds the standard hardening headers and a default CSP when a route sets none.
+
+// The four headers every response should carry. Strict-Transport-Security is
+// deliberately absent: Cloudflare's edge already injects HSTS on this zone, so
+// setting it here would produce a duplicate header.
+export const BASE_SECURITY_HEADERS: Record<string, string> = {
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Permissions-Policy':
+    'accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), usb=()',
+};
+
+// Applied only to responses that do not already declare their own CSP. Matches
+// the policy the dynamic routes set individually: allows the Cloudflare
+// analytics beacon and inline style attributes, blocks everything else.
+export const DEFAULT_CSP =
+  "default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self'; connect-src 'self' https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self';";
+
+/**
+ * Returns a copy of the response with the standard security headers applied.
+ * Existing headers (including a route-specific Content-Security-Policy) are
+ * preserved; only the base hardening headers are forced, and the default CSP
+ * is added solely when the response carries none.
+ */
+export function withSecurityHeaders(response: Response): Response {
+  const headers = new Headers(response.headers);
+
+  for (const [name, value] of Object.entries(BASE_SECURITY_HEADERS)) {
+    headers.set(name, value);
+  }
+
+  if (!headers.has('Content-Security-Policy')) {
+    headers.set('Content-Security-Policy', DEFAULT_CSP);
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/tests/integration/securityHeaders.test.ts
+++ b/tests/integration/securityHeaders.test.ts
@@ -48,11 +48,15 @@ describe('Worker security headers', () => {
   });
 
   it('does not clobber a route that sets its own CSP', async () => {
-    // /updates/feed.xml sets a route-specific CSP; the wrapper must keep it.
-    const request = new Request('http://localhost/updates/feed.xml');
+    // /admin sets a route-specific CSP whose script-src includes 'unsafe-inline'
+    // — a directive DEFAULT_CSP deliberately omits. Asserting on it proves the
+    // route policy survived rather than being overwritten with the default.
+    const request = new Request('http://localhost/admin');
     const response = await worker.fetch(request, createMockEnv(), ctx);
 
-    expect(response.headers.get('Content-Security-Policy')).toContain("default-src 'self'");
+    const csp = response.headers.get('Content-Security-Policy') ?? '';
+    expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+    expect(csp).not.toBe(DEFAULT_CSP);
     // ...while still gaining the base headers it previously lacked.
     expect(response.headers.get('X-Frame-Options')).toBe('DENY');
   });

--- a/tests/integration/securityHeaders.test.ts
+++ b/tests/integration/securityHeaders.test.ts
@@ -1,0 +1,59 @@
+// ABOUT: Integration tests confirming the Worker applies security headers
+// ABOUT: Verifies the withSecurityHeaders wrapper is wired into the default export
+
+import { describe, it, expect } from 'vitest';
+import worker from '@/index';
+import { createMockEnv } from '../mocks/env';
+import { createMockContext } from '../mocks/context';
+import { DEFAULT_CSP } from '@/securityHeaders';
+import type { Env } from '@/types';
+
+describe('Worker security headers', () => {
+  const ctx = createMockContext();
+
+  it('adds the base security headers and default CSP to a 404 response', async () => {
+    const request = new Request('http://localhost/no-such-page');
+    const response = await worker.fetch(request, createMockEnv(), ctx);
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+    expect(response.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+    expect(response.headers.get('Permissions-Policy')).toContain('camera=()');
+    expect(response.headers.get('Content-Security-Policy')).toBe(DEFAULT_CSP);
+  });
+
+  it('hardens the homepage served via env.ASSETS.fetch()', async () => {
+    // The homepage scored D because "/" returns the raw Cloudflare Assets
+    // response. Under run_worker_first the Worker sees that response, so the
+    // wrapper must add headers to it. Mock ASSETS to assert exactly that.
+    const env = createMockEnv({
+      ASSETS: {
+        fetch: async () =>
+          new Response('<!doctype html><html></html>', {
+            headers: { 'Content-Type': 'text/html' },
+          }),
+      } as unknown as Env['ASSETS'],
+    });
+
+    const response = await worker.fetch(new Request('http://localhost/'), env, ctx);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/html');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+    expect(response.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+    expect(response.headers.get('Permissions-Policy')).toContain('camera=()');
+    expect(response.headers.get('Content-Security-Policy')).toBe(DEFAULT_CSP);
+  });
+
+  it('does not clobber a route that sets its own CSP', async () => {
+    // /updates/feed.xml sets a route-specific CSP; the wrapper must keep it.
+    const request = new Request('http://localhost/updates/feed.xml');
+    const response = await worker.fetch(request, createMockEnv(), ctx);
+
+    expect(response.headers.get('Content-Security-Policy')).toContain("default-src 'self'");
+    // ...while still gaining the base headers it previously lacked.
+    expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+  });
+});

--- a/tests/unit/securityHeaders.test.ts
+++ b/tests/unit/securityHeaders.test.ts
@@ -1,0 +1,62 @@
+// ABOUT: Unit tests for the withSecurityHeaders response wrapper
+// ABOUT: Validates header injection, CSP preservation, and body/status passthrough
+
+import { describe, it, expect } from 'vitest';
+import { withSecurityHeaders, BASE_SECURITY_HEADERS, DEFAULT_CSP } from '@/securityHeaders';
+
+describe('withSecurityHeaders', () => {
+  it('adds every base security header', () => {
+    const result = withSecurityHeaders(new Response('hello'));
+
+    for (const [name, value] of Object.entries(BASE_SECURITY_HEADERS)) {
+      expect(result.headers.get(name)).toBe(value);
+    }
+  });
+
+  it('does not set Strict-Transport-Security (Cloudflare edge owns it)', () => {
+    const result = withSecurityHeaders(new Response('hello'));
+    expect(result.headers.has('Strict-Transport-Security')).toBe(false);
+  });
+
+  it('applies the default CSP when the response has none', () => {
+    const result = withSecurityHeaders(new Response('hello'));
+    expect(result.headers.get('Content-Security-Policy')).toBe(DEFAULT_CSP);
+  });
+
+  it('preserves a route-specific CSP instead of overwriting it', () => {
+    const routeCsp = "default-src 'self'; frame-src https://goodreads.com;";
+    const source = new Response('hello', {
+      headers: { 'Content-Security-Policy': routeCsp },
+    });
+
+    const result = withSecurityHeaders(source);
+    expect(result.headers.get('Content-Security-Policy')).toBe(routeCsp);
+  });
+
+  it('preserves status, statusText, and body', async () => {
+    const source = new Response('not here', { status: 404, statusText: 'Not Found' });
+    const result = withSecurityHeaders(source);
+
+    expect(result.status).toBe(404);
+    expect(result.statusText).toBe('Not Found');
+    expect(await result.text()).toBe('not here');
+  });
+
+  it('preserves pre-existing unrelated headers such as Content-Type', () => {
+    const source = new Response('<p>hi</p>', {
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+
+    const result = withSecurityHeaders(source);
+    expect(result.headers.get('Content-Type')).toBe('text/html; charset=utf-8');
+  });
+
+  it('forces X-Frame-Options even when the source set a weaker value', () => {
+    const source = new Response('hi', {
+      headers: { 'X-Frame-Options': 'SAMEORIGIN' },
+    });
+
+    const result = withSecurityHeaders(source);
+    expect(result.headers.get('X-Frame-Options')).toBe('DENY');
+  });
+});


### PR DESCRIPTION
## Why

A securityheaders.com scan of hultberg.org graded **D**. The homepage (`/`) returned the raw Cloudflare Assets response with **zero** security headers, and every page was missing `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, and `Permissions-Policy` (only the dynamic routes set a CSP).

## What changed

- **`src/securityHeaders.ts`** — `withSecurityHeaders()` forces the four hardening headers on every response and adds a default CSP **only when a route sets none**, so existing per-route CSPs (admin, `/now`, etc.) are preserved untouched.
- **`src/index.ts`** — routing extracted into `handleRequest()`; the single exit point is wrapped so the homepage, all dynamic routes, and the 404 are hardened.
- **`public/_headers`** — the same four headers for static assets that bypass the Worker (legacy `/2005/` pages, images). **No CSP here on purpose**, so the archived third-party embeds keep working.
- **HSTS** is deliberately *not* set in code — Cloudflare's edge already injects it; duplicating would be wrong.
- Tests for the wrapper plus the homepage and route-CSP-preservation paths; `REFERENCE/blog-security.md` updated.

## Headers after this change

| Header | Source |
|---|---|
| Content-Security-Policy | per-route, or default from wrapper |
| X-Content-Type-Options: nosniff | wrapper / `_headers` |
| X-Frame-Options: DENY | wrapper / `_headers` |
| Referrer-Policy: strict-origin-when-cross-origin | wrapper / `_headers` |
| Permissions-Policy (restrictive) | wrapper / `_headers` |
| Strict-Transport-Security | Cloudflare edge |

## Verification

- `npx tsc --noEmit` clean; full suite **561 tests pass**; coverage gate passes.
- New integration test mocks `env.ASSETS` to prove the **homepage** path comes out hardened.
- `/now` widgets unaffected: its own CSP is preserved, and `X-Frame-Options` only governs *being framed*, not the Goodreads iframe it embeds.

## Post-deploy notes (not code)

- Confirm the grade by re-scanning securityheaders.com **after a Cloudflare cache purge** — the homepage is edge-cached (`cf-cache-status: HIT`), so a stale copy could still show D briefly.
- Optional: lengthen HSTS `max-age` (currently 30 days) and add `preload` via the Cloudflare dashboard for preload eligibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)