### PR TITLE
Add takt.hultberg.org link to homepage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,7 @@
 <p>if you came here <a href="/2005/11/recipe_sharing_.html">looking for the recipe for the Swedish classic "Flying Jacob", you struck gold</a>!</p>
 <p>see what I'm up to <a href="/now">/now</a></p>
 <p>or read my <a href="/updates">/updates</a></p>
+<p>or <a href="https://takt.hultberg.org/" target="_blank">use your voice to set your workout pace</a> next session</p>
 <p>or play <a href="https://hnefatafl.hultberg.org/" target="_blank">the Viking board game Hnefatafl</a>, lovingly restored from the Copenhagen rules</p>
 <p>
     or browse a


### PR DESCRIPTION
## What
Adds a new line to the homepage, after the `/updates` link:

> or [use your voice to set your workout pace](https://takt.hultberg.org/) next session

The phrase links to https://takt.hultberg.org/ and opens in a new tab, matching the existing style of the other off-site project links.

## Testing
- `npm test` — 561 passing (no homepage assertions affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)