### PR TITLE
Add 'is Andy Burnham PM yet?' link to homepage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,7 @@
 <p>if you came here <a href="/2005/11/recipe_sharing_.html">looking for the recipe for the Swedish classic "Flying Jacob", you struck gold</a>!</p>
 <p>see what I'm up to <a href="/now">/now</a></p>
 <p>or read my <a href="/updates">/updates</a></p>
+<p>or get the answer to the question <a href="https://andyburnhamyet.hultberg.org/" target="_blank">is Andy Burnham PM yet</a>?</p>
 <p>or <a href="https://takt.hultberg.org/" target="_blank">use your voice to set your workout pace</a> next session</p>
 <p>or play <a href="https://hnefatafl.hultberg.org/" target="_blank">the Viking board game Hnefatafl</a>, lovingly restored from the Copenhagen rules</p>
 <p>


### PR DESCRIPTION
Adds an external link below `/updates` on the homepage pointing to https://andyburnhamyet.hultberg.org/, opening in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)